### PR TITLE
✨ feat: 사용자 정보를 활용한 API 요청 추가

### DIFF
--- a/app/services/hub_connect_service.py
+++ b/app/services/hub_connect_service.py
@@ -256,7 +256,8 @@ class HubConnectService:
     async def get_model_detail(
             self,
             model_id: str,
-            market: str
+            market: str,
+            user_info: Optional[Dict[str, str]] = None
     ) -> Optional[HubModelResponse]:
         """특정 모델 상세 정보 조회"""
         try:
@@ -266,7 +267,7 @@ class HubConnectService:
             logger.info(f"Getting hub model detail from: {url}")
 
             response = await self._make_authenticated_request(
-                "GET", url, params=params
+                "GET", url, user_info=user_info, params=params
             )
 
             if response.status_code == 200:
@@ -357,12 +358,11 @@ class HubConnectService:
                 detail=f"Internal error: {str(e)}"
             )
 
-    async def get_all_tags(self, market: str) -> TagListResponse:
+    async def get_all_tags(self, market: str, user_info: Optional[Dict[str, str]] = None) -> TagListResponse:
         """전체 태그 목록 조회"""
         try:
             url = f"{self.base_url}/tags/"
             params = {"market": market}
-            user_info: Optional[Dict[str, str]] = None
 
             logger.info(f"Getting all tags from: {url} with market: {market}")
 
@@ -409,13 +409,11 @@ class HubConnectService:
                 detail=f"Internal error: {str(e)}"
             )
 
-    async def get_tags_by_group(self, group: str, market: str) -> TagGroupResponse:
+    async def get_tags_by_group(self, group: str, market: str, user_info: Optional[Dict[str, str]] = None) -> TagGroupResponse:
         """특정 그룹의 태그 목록 조회"""
         try:
             url = f"{self.base_url}/tags/{group}"
             params = {"market": market}
-            user_info: Optional[Dict[str, str]] = None
-
 
             logger.info(f"Getting tags for group '{group}' from: {url} with market: {market}")
 


### PR DESCRIPTION
## 작업 소개
- `hub_connect_service`에 사용자 정보를 추가하여
- 모델 상세 정보, 파일 목록, 태그 목록 조회 시
- 사용자 정보를 함께 전달하도록 수정
- `get_model_detail`, `get_model_files`,
- `get_all_tags`, `get_tags_by_group` 함수 수정
- `_create_user_info_dict` 함수 추가하여
- 사용자 정보를 딕셔너리 형태로 변환
- 라우터에 사용자 정보 전달 및 활용 로직 추가

## 관련 Issue
<!-- 관련된 이슈 번호 -->
#30 
