### PR TITLE
🚀 release: 보안 대응 3건 + 워크플로우·모델·학습 API 확장 및 배포 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ develop ]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
       run: |
         docker stop ai-paas-gateway-api || true
         docker rm ai-paas-gateway-api || true
-        docker run --env-file .env -d --name ai-paas-gateway-api -p 8106:8000 ai-paas-gateway:latest
+        docker run --env-file .env -d --name ai-paas-gateway-api -p 8000:8000 ai-paas-gateway:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner: [aipaas-backend, ai-paas-gateway]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ coverage.xml
 # 로컬 전용 테스트
 docs/reports/
 /backups/
+
+# 로컬 전용 스크립트/덤프 (MLOps OpenAPI 비교, 임시 토큰, 테스트 등)
+# 관리 규약: 커밋할 개발 도구는 scripts/ 직하, 로컬 전용은 scripts/local/ 하위에 배치
+scripts/local/

--- a/alembic.ini
+++ b/alembic.ini
@@ -53,7 +53,9 @@ version_path_separator = os
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://***REDACTED***:***REDACTED******REDACTED***:5432/aipaas
+# DB URL is injected from the DATABASE_URL environment variable
+# (loaded in alembic/env.py). Do NOT hardcode connection details here.
+sqlalchemy.url =
 
 
 [post_write_hooks]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -19,10 +19,15 @@ from app.models import Base
 # access to the values within the .ini file in use.
 config = context.config
 
-# 환경변수에서 DATABASE_URL 가져와서 설정
+# 환경변수에서 DATABASE_URL 가져와서 설정.
+# alembic.ini에는 sqlalchemy.url을 하드코딩하지 않으므로, 이 값이 없으면 마이그레이션 중단.
 database_url = os.getenv("DATABASE_URL")
-if database_url:
-    config.set_main_option("sqlalchemy.url", database_url)
+if not database_url:
+    raise RuntimeError(
+        "DATABASE_URL environment variable is required for Alembic migrations. "
+        "Set it in .env (see .env.example) before running alembic commands."
+    )
+config.set_main_option("sqlalchemy.url", database_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/app/cruds/dataset.py
+++ b/app/cruds/dataset.py
@@ -182,6 +182,75 @@ class DatasetCRUD:
         db.refresh(db_dataset)
         return db_dataset
 
+    def upsert_dataset_mapping(
+            self,
+            db: Session,
+            surro_dataset_id: int,
+            member_id: str,
+            dataset_name: str = None
+    ) -> Dataset:
+        """삭제 여부와 관계없이 매핑을 생성하거나 재활성화한다."""
+        existing = db.query(Dataset).filter(
+            and_(
+                Dataset.surro_dataset_id == surro_dataset_id,
+                Dataset.created_by == member_id
+            )
+        ).order_by(Dataset.id.desc()).first()
+
+        if existing:
+            existing.name = dataset_name
+            existing.is_active = True
+            existing.deleted_at = None
+            existing.deleted_by = None
+            existing.updated_by = member_id
+            existing.updated_at = datetime.utcnow()
+            db.commit()
+            db.refresh(existing)
+            return existing
+
+        return self.create_dataset_mapping(
+            db=db,
+            surro_dataset_id=surro_dataset_id,
+            member_id=member_id,
+            dataset_name=dataset_name
+        )
+
+    def soft_delete_missing_mappings(
+            self,
+            db: Session,
+            member_id: str,
+            active_surro_dataset_ids: List[int],
+            deleted_by: Optional[str] = None
+    ) -> int:
+        """외부 목록에 없는 활성 매핑을 소프트 삭제한다."""
+        active_id_set = set(active_surro_dataset_ids)
+        targets = db.query(Dataset).filter(
+            and_(
+                Dataset.created_by == member_id,
+                Dataset.deleted_at.is_(None),
+                Dataset.is_active == True
+            )
+        ).all()
+
+        deleted_count = 0
+        deleted_actor = deleted_by or member_id
+        now = datetime.utcnow()
+
+        for dataset in targets:
+            if dataset.surro_dataset_id in active_id_set:
+                continue
+            dataset.is_active = False
+            dataset.deleted_at = now
+            dataset.deleted_by = deleted_actor
+            dataset.updated_by = deleted_actor
+            dataset.updated_at = now
+            deleted_count += 1
+
+        if deleted_count:
+            db.commit()
+
+        return deleted_count
+
     def delete_dataset_mapping(
             self,
             db: Session,

--- a/app/cruds/experiment.py
+++ b/app/cruds/experiment.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import and_
-from typing import Optional, List
+from sqlalchemy import and_, or_
+from typing import Optional, List, Tuple
 from datetime import datetime
 
 from app.models.experiment import Experiment
@@ -18,6 +18,36 @@ class ExperimentCRUD:
             )
         ).all()
         return [e.surro_experiment_id for e in experiments if e.surro_experiment_id]
+
+    def search_experiments_by_member_id(
+        self,
+        db: Session,
+        member_id: str,
+        skip: int = 0,
+        limit: int = 20,
+        search: Optional[str] = None,
+    ) -> Tuple[List[Experiment], int]:
+        """로컬 실험 매핑 검색"""
+        query = db.query(Experiment).filter(
+            and_(
+                Experiment.created_by == member_id,
+                Experiment.deleted_at.is_(None),
+            )
+        )
+
+        if search:
+            search_filter = f"%{search}%"
+            query = query.filter(
+                or_(
+                    Experiment.name.ilike(search_filter),
+                    Experiment.description.ilike(search_filter),
+                )
+            )
+
+        query = query.order_by(Experiment.surro_experiment_id.desc())
+        total = query.count()
+        experiments = query.offset(skip).limit(limit).all()
+        return experiments, total
 
     def get_experiment_by_surro_id(self, db: Session, surro_experiment_id: int, member_id: str) -> Optional[Experiment]:
         """외부 실험 ID와 멤버 ID로 조회"""

--- a/app/main.py
+++ b/app/main.py
@@ -12,14 +12,13 @@ from app.routes import (
     any_cloud,
     auth,
     dataset,
-    experiment,
     hub_connect,
     knowledge_base,
+    learning,
     lite_model,
     member,
     model,
     model_improvement,
-    pipeline,
     prompt,
     service,
     workflow,
@@ -62,8 +61,7 @@ app.include_router(service.router, prefix=settings.API_V1_STR)
 app.include_router(member.router, prefix=settings.API_V1_STR)
 app.include_router(workflow.router, prefix=settings.API_V1_STR)
 app.include_router(dataset.router, prefix=settings.API_V1_STR)
-app.include_router(pipeline.router, prefix=settings.API_V1_STR)
-app.include_router(experiment.router, prefix=settings.API_V1_STR)
+app.include_router(learning.router, prefix=settings.API_V1_STR)
 app.include_router(model_improvement.router, prefix=settings.API_V1_STR)
 app.include_router(model.router, prefix=settings.API_V1_STR)
 app.include_router(prompt.router, prefix=settings.API_V1_STR)

--- a/app/routes/learning.py
+++ b/app/routes/learning.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from sqlalchemy.orm import Session
@@ -12,6 +13,7 @@ from app.schemas.experiment import (
     ExperimentDetailResponse,
     ExperimentInternalUpdateRequest,
     ExperimentListItem,
+    ExperimentListResponse,
     ExperimentReadResponse,
     ExperimentUpdateRequest,
 )
@@ -28,6 +30,43 @@ from app.services.pipeline_service import pipeline_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/learning", tags=["Learning"])
+SEARCH_DETAIL_CONCURRENCY = 5
+
+
+def _create_pagination_response(data, total: int, page: int, size: int):
+    return {
+        "data": data,
+        "total": total,
+        "page": page,
+        "size": size,
+    }
+
+
+async def _fetch_learning_details(
+    experiment_ids: List[int],
+    current_user: Member,
+) -> List[dict]:
+    semaphore = asyncio.Semaphore(SEARCH_DETAIL_CONCURRENCY)
+
+    async def _fetch_one(experiment_id: int):
+        async with semaphore:
+            try:
+                return await experiment_service.get_experiment(
+                    experiment_id=experiment_id,
+                    user_info={
+                        "member_id": current_user.member_id,
+                        "role": current_user.role,
+                        "name": current_user.name,
+                    },
+                )
+            except Exception as detail_error:
+                logger.warning(
+                    f"Failed to fetch learning detail for experiment {experiment_id}: {str(detail_error)}"
+                )
+                return None
+
+    results = await asyncio.gather(*[_fetch_one(experiment_id) for experiment_id in experiment_ids])
+    return [result for result in results if result is not None]
 
 
 async def _sync_external_experiments_for_admin(db: Session, current_user: Member) -> set[int]:
@@ -76,10 +115,56 @@ async def _sync_external_experiments_for_admin(db: Session, current_user: Member
     return owned_ids
 
 
-@router.get("", response_model=List[ExperimentListItem], summary="List Learning")
+@router.get(
+    "",
+    response_model=ExperimentListResponse,
+    summary="List Learning",
+    description="""
+학습 목록 조회
+
+파이프라인 학습 실행으로 생성된 학습 항목의 목록을 반환합니다.
+게이트웨이에서 사용자 소유 학습만 필터링한 뒤 페이지네이션하여 응답합니다.
+
+## Query Parameters
+- **page** (int, optional): 페이지 번호
+  - 기본값: `1`
+  - 최소값: `1`
+- **size** (int, optional): 페이지당 항목 수
+  - 기본값: `20`
+  - 범위: `1-100`
+
+## Response (ExperimentListResponse)
+- **data** (List[ExperimentListItem]): 학습 목록
+- **total** (int): 전체 항목 수
+- **page** (int): 현재 페이지 번호
+- **size** (int): 페이지당 항목 수
+
+`data`의 각 항목은 다음 정보를 포함합니다.
+- **id** (int): 학습 ID
+- **name** (str): 학습 이름
+- **description** (str, optional): 학습 설명
+- **status** (str): 학습 상태
+- **registration_status** (str): 모델 등록 상태
+- **registered_model_id** (int | null): 등록된 모델 ID
+- **elapsed_time** (int): 경과 시간
+- **end_time** (datetime | null): 종료 시각
+- **reference_model**: 참조 모델 요약 정보
+- **dataset**: 데이터셋 요약 정보
+- **created_at** (datetime): 생성 시각
+- **updated_at** (datetime): 수정 시각
+
+## Notes
+- 외부 MLOps 실험 목록을 게이트웨이에서 사용자 소유 기준으로 필터링한 뒤 응답합니다.
+
+## Errors
+- 401: 인증되지 않은 사용자
+- 500: 서버 내부 오류
+""",
+)
 async def list_learning(
-    skip: int = Query(0, ge=0, description="Number of items to skip"),
-    limit: int = Query(100, ge=1, le=1000, description="Maximum number of items to return"),
+    page: int = Query(1, ge=1, description="페이지 번호 (1부터 시작)"),
+    size: int = Query(20, ge=1, le=100, description="페이지당 항목 수"),
+    search: Optional[str] = Query(None, description="검색어 (이름, 설명)"),
     db: Session = Depends(get_db),
     current_user: Member = Depends(get_current_user),
 ):
@@ -97,8 +182,13 @@ async def list_learning(
         - 기본값: `100`
         - 범위: `1-1000`
 
-    ## Response (List[ExperimentListItem])
-    각 항목은 다음 정보를 포함합니다.
+    ## Response (ExperimentListResponse)
+    - **data** (List[ExperimentListItem]): 학습 목록
+    - **total** (int): 전체 항목 수
+    - **page** (int): 현재 페이지 번호
+    - **size** (int): 페이지당 항목 수
+
+    `data`의 각 항목은 다음 정보를 포함합니다.
     - **id** (int): 학습 ID
     - **name** (str): 학습 이름
     - **description** (str, optional): 학습 설명
@@ -116,9 +206,46 @@ async def list_learning(
     - 500: 서버 내부 오류
     """
     try:
+        skip = (page - 1) * size
         owned_ids = await _sync_external_experiments_for_admin(db, current_user)
+
+        if search:
+            local_matches, total = experiment_crud.search_experiments_by_member_id(
+                db=db,
+                member_id=current_user.member_id,
+                skip=skip,
+                limit=size,
+                search=search,
+            )
+            if not local_matches:
+                return _create_pagination_response([], total, page, size)
+
+            page_ids = [exp.surro_experiment_id for exp in local_matches if exp.surro_experiment_id]
+            details = await _fetch_learning_details(page_ids, current_user)
+
+            for detail in details:
+                if detail.get("id") is None:
+                    continue
+                experiment_crud.update_mapping(
+                    db=db,
+                    surro_experiment_id=detail["id"],
+                    member_id=current_user.member_id,
+                    update_data={
+                        "name": detail.get("name"),
+                        "description": detail.get("description"),
+                    },
+                )
+
+            detail_by_id = {
+                detail["id"]: detail
+                for detail in details
+                if detail.get("id") is not None
+            }
+            ordered = [detail_by_id[experiment_id] for experiment_id in page_ids if experiment_id in detail_by_id]
+            return _create_pagination_response(ordered, total, page, size)
+
         if not owned_ids:
-            return []
+            return _create_pagination_response([], 0, page, size)
 
         all_experiments = await experiment_service.list_experiments(
             skip=0,
@@ -131,7 +258,8 @@ async def list_learning(
         )
 
         filtered = [exp for exp in all_experiments if exp.get("id") in owned_ids]
-        return filtered[skip:skip + limit]
+        total = len(filtered)
+        return _create_pagination_response(filtered[skip:skip + size], total, page, size)
 
     except HTTPException:
         raise

--- a/app/routes/learning.py
+++ b/app/routes/learning.py
@@ -1,0 +1,581 @@
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_admin_user, get_current_user
+from app.cruds import experiment_crud
+from app.database import get_db
+from app.models import Member
+from app.schemas.experiment import (
+    ExperimentDetailResponse,
+    ExperimentInternalUpdateRequest,
+    ExperimentListItem,
+    ExperimentReadResponse,
+    ExperimentUpdateRequest,
+)
+from app.schemas.pipeline import (
+    ModelRegistrationRequest,
+    ModelRegistrationResponse,
+    TrainingPipelineRequest,
+    TrainingPipelineResponse,
+    TrainingStatusResponse,
+)
+from app.services.experiment_service import experiment_service
+from app.services.pipeline_service import pipeline_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/learning", tags=["Learning"])
+
+
+async def _sync_external_experiments_for_admin(db: Session, current_user: Member) -> set[int]:
+    # External MLOps still exposes training through the legacy pipeline/experiments APIs.
+    # The gateway keeps a local experiments mapping table so the frontend can use the
+    # unified learning domain while ownership checks remain gateway-controlled.
+    owned_ids = set(experiment_crud.get_experiments_by_member_id(db, current_user.member_id))
+
+    if current_user.role != "admin":
+        return owned_ids
+
+    all_experiments = await experiment_service.list_experiments(
+        skip=0,
+        limit=1000,
+        user_info={
+            "member_id": current_user.member_id,
+            "role": current_user.role,
+            "name": current_user.name,
+        },
+    )
+
+    missing = [exp for exp in all_experiments if exp.get("id") not in owned_ids]
+    for exp in missing:
+        exp_id = exp.get("id")
+        if not exp_id:
+            continue
+        try:
+            reference_model = exp.get("reference_model") or {}
+            dataset = exp.get("dataset") or {}
+            experiment_crud.create_mapping(
+                db=db,
+                surro_experiment_id=exp_id,
+                member_id=current_user.member_id,
+                name=exp.get("name"),
+                description=exp.get("description"),
+                model_id=reference_model.get("id") or exp.get("reference_model_id"),
+                dataset_id=dataset.get("id") or exp.get("dataset_id"),
+            )
+            owned_ids.add(exp_id)
+            logger.info(
+                f"Registered missing experiment under admin ({current_user.member_id}): surro_id={exp_id}"
+            )
+        except Exception as sync_error:
+            logger.warning(f"Failed to sync external experiment {exp_id}: {str(sync_error)}")
+
+    return owned_ids
+
+
+@router.get("", response_model=List[ExperimentListItem], summary="List Learning")
+async def list_learning(
+    skip: int = Query(0, ge=0, description="Number of items to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of items to return"),
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 목록 조회
+
+    파이프라인 학습 실행으로 생성된 학습 항목의 목록을 반환합니다.
+    게이트웨이에서 사용자 소유 학습만 필터링한 뒤, 프론트엔드와 약속된 `skip`/`limit` 방식으로 페이지네이션하여 응답합니다.
+
+    ## Query Parameters
+    - **skip** (int, optional): 건너뛸 항목 수
+        - 기본값: `0`
+        - 최소값: `0`
+    - **limit** (int, optional): 반환할 최대 항목 수
+        - 기본값: `100`
+        - 범위: `1-1000`
+
+    ## Response (List[ExperimentListItem])
+    각 항목은 다음 정보를 포함합니다.
+    - **id** (int): 학습 ID
+    - **name** (str): 학습 이름
+    - **description** (str, optional): 학습 설명
+    - **status** (str): 학습 상태
+    - **model registration status 관련 요약 정보**
+    - **경과 시간, 종료 시간 등 요약 정보**
+
+    ## Notes
+    - 외부 MLOps API의 실험 목록을 게이트웨이에서 사용자 기준으로 필터링한 후 응답합니다.
+    - 프론트엔드 연동 규약에 따라 게이트웨이에서는 `skip`/`limit` 방식 페이지네이션을 유지합니다.
+    - 외부 API의 페이지 파라미터 형식은 게이트웨이 내부에서만 사용되며 프론트엔드에 그대로 노출하지 않습니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 500: 서버 내부 오류
+    """
+    try:
+        owned_ids = await _sync_external_experiments_for_admin(db, current_user)
+        if not owned_ids:
+            return []
+
+        all_experiments = await experiment_service.list_experiments(
+            skip=0,
+            limit=1000,
+            user_info={
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
+        )
+
+        filtered = [exp for exp in all_experiments if exp.get("id") in owned_ids]
+        return filtered[skip:skip + limit]
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error listing learning items for user {current_user.member_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list learning items: {str(e)}",
+        )
+
+
+@router.post("/training", response_model=TrainingPipelineResponse, summary="Submit Training")
+async def submit_training(
+    request: TrainingPipelineRequest,
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 파이프라인 생성 및 실행
+
+    모델과 데이터셋을 사용하여 Kubeflow Pipeline 기반의 학습 파이프라인을 생성하고 실행합니다.
+    요청은 전체 Body(JSON)로 전달되며, 학습 시작 후 백그라운드에서 MLflow 메트릭 폴링이 시작됩니다.
+
+    ## Response (TrainingPipelineResponse)
+    - **experiment_id** (int | null): 생성된 학습 ID
+
+    ## Notes
+    - 외부 MLOps API에는 기존 pipeline 학습 API로 요청하지만, 게이트웨이에서는 learning 도메인으로 통합하여 제공합니다.
+    - 학습 생성 성공 시 게이트웨이 DB에 사용자-학습 매핑 정보를 함께 저장합니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 422: 요청 본문 검증 실패
+    - 500: 서버 내부 오류
+    """
+    try:
+        result = await pipeline_service.submit_training(
+            data=request.model_dump(),
+            user_info={
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
+        )
+
+        experiment_id = result.get("experiment_id")
+        if experiment_id:
+            try:
+                experiment_crud.create_mapping(
+                    db=db,
+                    surro_experiment_id=experiment_id,
+                    member_id=current_user.member_id,
+                    name=request.train_name,
+                    description=request.description,
+                    model_id=request.model_id,
+                    dataset_id=request.dataset_id,
+                )
+                logger.info(
+                    f"Created experiment mapping: surro_id={experiment_id}, member_id={current_user.member_id}"
+                )
+            except Exception as mapping_error:
+                logger.warning(f"Failed to create experiment mapping: {str(mapping_error)}")
+
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error submitting training for user {current_user.member_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to submit training: {str(e)}",
+        )
+
+
+@router.post("/model/registration", response_model=ModelRegistrationResponse, summary="Register Model")
+async def register_model(
+    request: ModelRegistrationRequest,
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 완료 모델 등록 파이프라인 실행
+
+    학습이 완료된 모델을 등록하는 파이프라인을 실행합니다.
+    기존 Query Parameter 방식이 아닌 Body(JSON) 기반 요청이며, 응답은 객체 형태로 반환됩니다.
+    KFP run_id를 저장하고 백그라운드에서 등록 상태 폴링이 시작됩니다.
+
+    ## Response (ModelRegistrationResponse)
+    - **accepted** (bool): 파이프라인 접수 여부
+    - **experiment_id** (int): 대상 학습 ID
+    - **message** (str): 처리 결과 메시지
+
+    ## Notes
+    - 외부 MLOps API에는 기존 pipeline 모델 등록 API로 요청합니다.
+    - 게이트웨이에서는 learning 도메인 하위의 모델 등록 흐름으로 통합 제공됩니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 422: 요청 본문 검증 실패
+    - 500: 서버 내부 오류
+    """
+    try:
+        result = await pipeline_service.register_model(
+            data=request.model_dump(),
+            user_info={
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error registering model for user {current_user.member_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to register model: {str(e)}",
+        )
+
+
+@router.get(
+    "/{experiment_id}/status",
+    response_model=TrainingStatusResponse,
+    deprecated=True,
+    summary="Get Training Status",
+)
+async def get_training_status(
+    experiment_id: int = Path(..., description="Learning ID"),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 상태 조회 (Deprecated)
+
+    `GET /api/v1/learning/{experiment_id}` 사용을 권장합니다.
+    기존 상태 전용 조회 경로와의 하위 호환을 위해 유지합니다.
+
+    ## Path Parameters
+    - **experiment_id** (int): 학습 ID
+
+    ## Response (TrainingStatusResponse)
+    - **status** (str): 학습 상태
+    - **start_time** (int): 시작 시각 (Unix timestamp)
+    - **end_time** (int, optional): 종료 시각 (Unix timestamp)
+    - **elapsed_time** (int): 경과 시간(초)
+    - **max_epoch** (int): 최대 epoch 수
+    - **current_epoch** (int): 현재 epoch
+    - **loss_history** (array): loss 이력
+    - **epoch_history** (array): epoch 이력
+    - **average_precision_50_history** (array): AP@50 이력
+    - **average_precision_75_history** (array): AP@75 이력
+    - **best_average_precision_history** (array): Best AP 이력
+    - **average_precision_50_95_history** (array): AP@50:95 이력
+
+    ## Notes
+    - 게이트웨이 내부에서는 기존 pipeline 상태 조회 API를 그대로 호출합니다.
+    - 신규 연동은 상세 조회 API 사용을 권장합니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
+    """
+    try:
+        result = await pipeline_service.get_training_status(
+            experiment_id=experiment_id,
+            user_info={
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting training status: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get training status: {str(e)}",
+        )
+
+
+@router.patch(
+    "/{experiment_id}/internal-access",
+    response_model=ExperimentReadResponse,
+    summary="Update Learning Internal",
+)
+async def update_learning_internal(
+    experiment_id: int = Path(..., description="Learning ID to update internally"),
+    update_data: ExperimentInternalUpdateRequest = ...,
+    current_user: Member = Depends(get_current_admin_user),
+):
+    """
+    내부 통신 전용 학습 정보 수정 API
+
+    시스템 내부 통신에서 사용하는 API로, `status`, `mlflow_run_id`, `kubeflow_run_id`를 수정할 수 있습니다.
+    관리자 권한이 필요합니다.
+
+    ## Path Parameters
+    - **experiment_id** (int): 수정할 학습 ID
+
+    ## Response (ExperimentReadResponse)
+    - 학습의 전체 정보를 반환합니다.
+
+    ## Notes
+    - 내부 상태 동기화 용도입니다.
+    - 외부 MLOps API에는 기존 experiments internal-access API로 요청합니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 403: 관리자 권한 필요
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
+    """
+    try:
+        user_info = {
+            "member_id": current_user.member_id,
+            "role": current_user.role,
+            "name": current_user.name,
+        }
+        update_payload = update_data.model_dump(exclude_unset=True)
+
+        result = await experiment_service.update_experiment_internal(
+            experiment_id=experiment_id,
+            update_data=update_payload,
+            user_info=user_info,
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating learning internal {experiment_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update learning internal: {str(e)}",
+        )
+
+
+@router.get("/{experiment_id}", response_model=ExperimentDetailResponse, summary="Get Learning")
+async def get_learning(
+    experiment_id: int = Path(..., description="Learning ID to retrieve"),
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 상세정보 조회
+
+    특정 학습의 상세 정보를 조회합니다.
+    목록 필드에 더해 학습 메트릭, 등록 상태, 메시지 정보를 통합 제공할 수 있는 상세 조회 API입니다.
+
+    ## Path Parameters
+    - **experiment_id** (int): 조회할 학습 ID
+
+    ## Response (ExperimentDetailResponse)
+    - **id** (int): 학습 ID
+    - **name** (str): 학습 이름
+    - **description** (str): 학습 설명
+    - **reference_model_id** (int): 참조 모델 ID
+    - **dataset_id** (int): 데이터셋 ID
+    - **kubeflow_run_id** (str, optional): Kubeflow 파이프라인 실행 ID
+    - **mlflow_run_id** (str, optional): MLflow 실행 ID
+    - **status** (str): 학습 상태
+    - **reference_model**: 참조 모델 상세 정보
+    - **dataset**: 데이터셋 상세 정보
+    - **hyperparameters**: 하이퍼파라미터 목록
+    - **created_at** (datetime): 생성 시각
+    - **updated_at** (datetime): 수정 시각
+
+    ## Notes
+    - 게이트웨이 DB에서 사용자 소유 여부를 먼저 검증한 뒤 외부 MLOps API를 조회합니다.
+    - 외부 실험 상세 응답을 게이트웨이의 learning 상세 조회로 매핑하여 제공합니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
+    """
+    try:
+        await _sync_external_experiments_for_admin(db, current_user)
+        if not experiment_crud.check_ownership(db, experiment_id, current_user.member_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Learning item not found or access denied",
+            )
+
+        result = await experiment_service.get_experiment(
+            experiment_id=experiment_id,
+            user_info={
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting learning item {experiment_id} for user {current_user.member_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get learning item: {str(e)}",
+        )
+
+
+@router.patch("/{experiment_id}", response_model=ExperimentReadResponse, summary="Update Learning")
+async def update_learning(
+    experiment_id: int = Path(..., description="Learning ID to update"),
+    update_data: ExperimentUpdateRequest = ...,
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 정보 수정
+
+    학습이 진행 중이거나 완료된 항목의 이름과 설명을 수정합니다.
+    학습 결과의 무결성을 위해 모델, 데이터셋, 하이퍼파라미터 등은 수정할 수 없습니다.
+
+    ## Path Parameters
+    - **experiment_id** (int): 수정할 학습 ID
+
+    ## Response (ExperimentReadResponse)
+    - **id** (int): 학습 ID
+    - **name** (str): 학습 이름
+    - **description** (str): 학습 설명
+    - **reference_model_id** (int): 참조 모델 ID
+    - **dataset_id** (int): 데이터셋 ID
+    - **kubeflow_run_id** (str, optional): Kubeflow 파이프라인 실행 ID
+    - **mlflow_run_id** (str, optional): MLflow 실행 ID
+    - **status** (str): 학습 상태
+    - **reference_model**: 참조 모델 상세 정보
+    - **dataset**: 데이터셋 상세 정보
+    - **hyperparameters**: 하이퍼파라미터 목록
+    - **created_at** (datetime): 생성 시각
+    - **updated_at** (datetime): 수정 시각
+
+    ## Notes
+    - 학습이 진행 중이거나 완료된 항목에서는 `name`과 `description`만 수정 가능합니다.
+    - `reference_model_id`, `dataset_id`, `hyperparameters` 등은 학습 결과의 무결성을 위해 수정할 수 없습니다.
+    - 제공된 필드만 업데이트되며, 생략된 필드는 기존 값이 유지됩니다.
+    - 외부 MLOps API에는 기존 experiments 수정 API로 요청하고, 게이트웨이 DB의 매핑 정보도 함께 갱신합니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
+    """
+    try:
+        await _sync_external_experiments_for_admin(db, current_user)
+        if not experiment_crud.check_ownership(db, experiment_id, current_user.member_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Learning item not found or access denied",
+            )
+
+        user_info = {
+            "member_id": current_user.member_id,
+            "role": current_user.role,
+            "name": current_user.name,
+        }
+        update_payload = update_data.model_dump(exclude_unset=True)
+
+        result = await experiment_service.update_experiment(
+            experiment_id=experiment_id,
+            update_data=update_payload,
+            user_info=user_info,
+        )
+
+        experiment_crud.update_mapping(
+            db=db,
+            surro_experiment_id=experiment_id,
+            member_id=current_user.member_id,
+            update_data=update_payload,
+        )
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating learning item {experiment_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update learning item: {str(e)}",
+        )
+
+
+@router.delete("/{experiment_id}", summary="Delete Learning")
+async def delete_learning(
+    experiment_id: int = Path(..., description="Learning ID to delete"),
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
+):
+    """
+    학습 삭제
+
+    학습 항목을 삭제합니다.
+    외부 MLOps 시스템의 MLflow artifacts와 S3 object까지 함께 삭제됩니다.
+
+    ## Path Parameters
+    - **experiment_id** (int): 삭제할 학습 ID
+
+    ## Response
+    - **message** (str): 삭제 성공 메시지
+
+    ## Notes
+    - 게이트웨이 DB에서 소유권 검증 후 외부 MLOps API 삭제를 요청합니다.
+    - 삭제 성공 시 게이트웨이 DB의 사용자-학습 매핑도 함께 제거됩니다.
+
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
+    """
+    try:
+        await _sync_external_experiments_for_admin(db, current_user)
+        if not experiment_crud.check_ownership(db, experiment_id, current_user.member_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Learning item not found or access denied",
+            )
+
+        user_info = {
+            "member_id": current_user.member_id,
+            "role": current_user.role,
+            "name": current_user.name,
+        }
+
+        result = await experiment_service.delete_experiment(
+            experiment_id=experiment_id,
+            user_info=user_info,
+        )
+
+        experiment_crud.delete_mapping(db, experiment_id, current_user.member_id)
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting learning item {experiment_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete learning item: {str(e)}",
+        )

--- a/app/routes/model.py
+++ b/app/routes/model.py
@@ -57,21 +57,79 @@ async def create_model(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    새 모델 생성
+    모델 등록
 
-    - Surro API에 모델을 생성한 후, Inno DB에 사용자-모델 매핑을 저장합니다.
+    Model Registry에 모델을 등록합니다.
+    제공자(provider)에 따라 HuggingFace 모델 또는 커스텀 모델로 등록됩니다.
+    게이트웨이는 MLOps에 등록한 뒤, 게이트웨이 DB에 사용자-모델 매핑을 저장합니다
+    (admin이 호출하면 `is_catalog=true`로 분류).
 
-    **주의사항**:
-    - `provider_id`, `type_id`, `format_id`는 각각 해당하는 조회 API를 먼저 호출하여 ID 값을 확인한 후 사용
-    - `parent_model_id`와 `model_registry_schema`는 내부 시스템 전용 (프론트엔드에서는 전달하지 않음)
-    - **HuggingFace 모델**: `provider_id`가 huggingface의 ID와 일치해야 함
-    - **커스텀 모델**: `provider_id`가 custom의 ID와 일치하고 `file`이 필요함
-    - 모델 이름에 "yolo" 포함 시 자동으로 학습 가능 모델로 설정됨
+    ## Request Body (multipart/form-data)
+    - **name** (str, required): 모델 이름
+        - 모델을 식별하기 위한 이름
+        - YOLOX 모델인 경우 학습 가능 모델로 자동 설정됨
+    - **description** (str, optional): 모델 설명
+    - **repo_id** (str, optional): 모델 저장소 ID
+        - HuggingFace 모델인 경우: repository ID (예: "google/owlv2-base-patch16")
+        - 커스텀 모델인 경우: 모델 식별자
+        - 생략 가능 (null 허용)
+    - **provider_id** (int, required): 모델 제공자 ID
+        - **중요**: `GET /api/v1/models/providers` 로 조회 후 `id` 값을 사용
+        - 하드코딩된 숫자 값을 사용하지 마세요
+    - **type_id** (int, required): 모델 타입 ID
+        - **중요**: `GET /api/v1/models/types` 로 조회 후 `id` 값을 사용
+    - **format_id** (int, required): 모델 포맷 ID
+        - **중요**: `GET /api/v1/models/formats` 로 조회 후 `id` 값을 사용
+    - **parent_model_id** (int, optional): 부모 모델 ID
+        - 내부 시스템 전용 — 프론트엔드에서 전달 금지
+    - **task** (str, optional): 모델 태스크
+        - 허용 값: "embedding", "text-generation", "object-detection" 중 하나
+        - 다른 값 입력 시 422 에러 발생
+    - **parameter** (str, optional): 모델 파라미터 (최대 100자)
+    - **sample_code** (str, optional): 샘플 코드
+    - **file** (UploadFile, optional): 커스텀 모델 파일 (binary)
+    - **model_registry_schema** (str, optional): 모델 레지스트리 스키마 (JSON 문자열)
+        - 내부 시스템 전용 — 프론트엔드에서 전달 금지
 
-    **파일 업로드**:
-    - `file` 파라미터에 바이너리 파일을 첨부
-    - Swagger UI에서 "Choose File" 버튼으로 업로드 가능
-    - Content-Type: multipart/form-data
+    ## Response (ModelBriefReadSchema)
+    - **id** (int): 모델 고유 ID
+    - **name** (str): 모델 이름
+    - **description** (str, optional): 모델 설명
+    - **repo_id** (str, optional): 모델 저장소 ID
+    - **provider_info** (ModelProviderReadSchema): 모델 제공자 정보
+        - id (int): 제공자 ID
+        - name (str): 제공자 이름
+        - description (str): 제공자 설명
+    - **type_info** (ModelTypeReadSchema): 모델 타입 정보
+        - id / name / description
+    - **format_info** (ModelFormatReadSchema): 모델 포맷 정보
+        - id / name / description
+    - **parent_model_id** (int, optional): 부모 모델 ID
+    - **task** (str, optional): 모델 태스크
+    - **parameter** (str, optional): 모델 파라미터
+    - **sample_code** (str, optional): 샘플 코드
+    - **registry** (ModelRegistryReadSchema): 모델 레지스트리 정보
+        - id (int): 레지스트리 ID
+        - artifact_path (str): 아티팩트 경로
+        - uri (str): 모델 URI
+        - run_id (str, optional): MLflow 실행 ID
+        - reference_model_id (int): 참조 모델 ID
+        - created_at / updated_at (datetime)
+    - **created_at** (datetime): 모델 생성 시각
+    - **updated_at** (datetime): 모델 수정 시각
+
+    ## Notes
+    - **ID 값 조회**: `provider_id`, `type_id`, `format_id`는 각각 해당 조회 API를 먼저 호출하여 확인 후 사용
+    - HuggingFace 모델인 경우 `provider_id`가 huggingface의 ID와 일치해야 함
+    - 커스텀 모델인 경우 `provider_id`가 custom의 ID와 일치해야 하며 `file` 필요
+    - YOLOX 모델인 경우에만 자동으로 학습 가능 모델(learning_enable_yn=True)로 설정
+    - `parent_model_id`와 `model_registry_schema`는 내부 시스템 전용 — 프론트엔드에서 전달 금지
+    - MLOps에는 등록되었으나 게이트웨이 DB 매핑 저장이 실패하면 경고만 로그하고 응답은 그대로 반환
+
+    ## Errors
+    - **400**: 유효하지 않은 요청 또는 필수 파라미터 누락
+    - **401**: 인증되지 않은 사용자
+    - **500**: 모델 등록 중 서버 내부 오류
     """
     try:
         # 파일 처리
@@ -155,23 +213,63 @@ async def get_all_models(
     """
     모델 목록 조회
 
-    현재 사용자가 등록한 모델 목록을 조회합니다.
-    페이지네이션을 지원하며, 모델 타입/프로바이더/포맷/공개 범위 기준으로 필터링할 수 있습니다.
+    등록된 모델들의 목록을 페이지네이션하여 조회합니다.
+    model_type_id, model_provider_id, model_format_id, filter_type을 사용하여 필터링할 수 있습니다.
+
+    게이트웨이는 MLOps 목록을 받아 게이트웨이 DB의 사용자-모델 매핑과 교차하여
+    현재 사용자가 접근 가능한 모델(본인 소유 + 카탈로그)만 반환합니다.
 
     ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+        - MLOps 원본의 `page_size`에 대응 — 게이트웨이-프론트 계약에 따라 `size`로 노출
+    - **search** (str, optional): 이름/설명 검색어 (게이트웨이 확장, MLOps 원본에는 없음)
+    - **model_type_id** (int, optional): 모델 타입 ID로 필터링
+        - `GET /api/v1/models/types` API로 타입 목록 조회 가능
+    - **model_provider_id** (int, optional): 모델 제공자 ID로 필터링
+        - `GET /api/v1/models/providers` API로 제공자 목록 조회 가능
+    - **model_format_id** (int, optional): 모델 포맷 ID로 필터링
+        - `GET /api/v1/models/formats` API로 포맷 목록 조회 가능
+    - **filter_type** (str, optional): 목록 구분 필터 (MLOps 원본의 `visibility`에 대응)
+        - `catalog`: 카탈로그 모델만 반환 (초기 등록 모델, 최적화 비대상)
+        - `custom`: 커스텀 모델만 반환 (사용자가 직접 등록한 모델)
+        - 생략 시: 본인 소유 + 카탈로그 전체 반환
 
-    - **page**: 페이지 번호 (기본값: 1)
-    - **page_size**: 페이지당 항목 수 (기본값: 20, 최대값은 외부 API 정책에 따름)
-    - **model_type_id**: 모델 타입 ID로 필터링
-    - **model_provider_id**: 모델 프로바이더 ID로 필터링
-    - **model_format_id**: 모델 포맷 ID로 필터링
-    - **visibility**: 공개 범위 필터 (`catalog`, `custom`)
+    ## Response (WrappedList)
+    게이트웨이-프론트 계약에 따라 `{data, total, page, size}` 래퍼로 반환:
+    - **data** (List[ModelBriefReadSchema]): 모델 목록
+        - id (int): 모델 고유 ID
+        - name (str): 모델 이름
+        - description (str, optional): 모델 설명
+        - repo_id (str, optional): 모델 저장소 ID
+        - provider_info (ModelProviderReadSchema): 모델 제공자 정보 (id/name/description)
+        - type_info (ModelTypeReadSchema): 모델 타입 정보 (id/name/description)
+        - format_info (ModelFormatReadSchema): 모델 포맷 정보 (id/name/description)
+        - parent_model_id (int, optional): 부모 모델 ID
+        - task (str, optional): 모델 태스크
+        - parameter (str, optional): 모델 파라미터
+        - sample_code (str, optional): 샘플 코드
+        - registry (ModelRegistryReadSchema): 모델 레지스트리 정보
+            - id, artifact_path, uri, run_id, reference_model_id, created_at, updated_at
+        - learning_enable_yn (bool): 학습 파이프라인 사용 가능 여부
+        - opt_enable_yn (bool): 최적화/경량화 대상 여부
+        - visibility (str): 모델 분류 (`CATALOG` 또는 `CUSTOM`)
+        - created_at (datetime): 모델 생성 시각
+        - updated_at (datetime): 모델 수정 시각
+    - **total** (int): 필터 조건에 맞는 전체 모델 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
 
     ## Notes
+    - page와 size 모두 지정되지 않으면 기본값(1, 20)으로 조회합니다
+    - 필터링 파라미터(model_type_id, model_provider_id, model_format_id, filter_type)는 함께 사용 가능
+    - 게이트웨이는 MLOps에서 받은 목록을 게이트웨이 DB의 매핑 정보로 필터링 후 페이지네이션합니다
+    - `search`/`filter_type`은 게이트웨이에서 처리되므로, MLOps에는 전달되지 않을 수 있습니다
 
-    - `catalog`는 시스템에서 제공하는 카탈로그 모델을 의미합니다.
-    - `custom`은 사용자가 직접 등록한 커스텀 모델을 의미합니다.
-    - 필터를 지정하지 않으면 전체 모델을 조회합니다.
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **422**: filter_type 값이 유효하지 않음 ('catalog' 또는 'custom'만 허용)
+    - **500**: 서버 내부 오류
     """
     try:
         # 1. Surro API에서 모델 조회 (MLOps 파라미터 변환은 서비스 내부에서 처리)
@@ -280,7 +378,35 @@ async def get_user_models(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    현재 로그인한 사용자가 생성한 모델만 조회 (페이지네이션 포함)
+    내 커스텀 모델 목록 조회 (게이트웨이 확장)
+
+    현재 로그인한 사용자가 직접 등록한 커스텀 모델만 조회합니다.
+    이 엔드포인트는 게이트웨이 전용이며, MLOps 원본 스펙에는 없습니다.
+    `GET /api/v1/models?filter_type=custom` 과 동등한 결과를 반환합니다.
+
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+    - **search** (str, optional): 이름/설명 검색어 (게이트웨이 자체 필터)
+    - **model_type_id** (int, optional): 모델 타입 ID 필터
+    - **model_provider_id** (int, optional): 모델 제공자 ID 필터
+    - **model_format_id** (int, optional): 모델 포맷 ID 필터
+
+    ## Response (WrappedList)
+    `{data, total, page, size}` 형식으로 반환:
+    - **data** (List[ModelBriefReadSchema]): 모델 목록 (필드는 `GET /models` 응답과 동일)
+    - **total** (int): 필터 조건에 맞는 전체 커스텀 모델 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
+
+    ## Notes
+    - 게이트웨이 DB의 `created_by == 현재 사용자`인 모델만 대상
+    - 삭제된 모델(`deleted_at` 설정됨)은 제외
+    - MLOps 원본에는 없는 게이트웨이 확장 엔드포인트
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     try:
         # 1. 사용자 커스텀 모델 ID 목록 조회 (전체)
@@ -370,7 +496,36 @@ async def get_catalog_models(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    모델 카탈로그 조회 (is_catalog가 true인 모델만, 페이지네이션 포함)
+    카탈로그 모델 목록 조회 (게이트웨이 확장)
+
+    관리자(admin)가 등록하여 카탈로그로 분류된(`is_catalog=true`) 모델만 조회합니다.
+    모든 사용자가 열람 가능한 공용 모델 목록입니다.
+    이 엔드포인트는 게이트웨이 전용이며, MLOps 원본 스펙에는 없습니다.
+    `GET /api/v1/models?filter_type=catalog` 과 동등한 결과를 반환합니다.
+
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+    - **search** (str, optional): 이름/설명 검색어 (게이트웨이 자체 필터)
+    - **model_type_id** (int, optional): 모델 타입 ID 필터
+    - **model_provider_id** (int, optional): 모델 제공자 ID 필터
+    - **model_format_id** (int, optional): 모델 포맷 ID 필터
+
+    ## Response (WrappedList)
+    `{data, total, page, size}` 형식으로 반환:
+    - **data** (List[ModelBriefReadSchema]): 모델 목록 (필드는 `GET /models` 응답과 동일)
+    - **total** (int): 필터 조건에 맞는 전체 카탈로그 모델 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
+
+    ## Notes
+    - 게이트웨이 DB의 `is_catalog=true`이며 `deleted_at`이 없는 모델만 대상
+    - 카탈로그 모델은 관리자 등록 시점에 자동으로 분류되며, 사용자 삭제 불가
+    - MLOps 원본에는 없는 게이트웨이 확장 엔드포인트
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     try:
         # 1. 카탈로그 모델 ID 목록 조회 (전체)
@@ -456,10 +611,37 @@ async def get_providers(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    모델 프로바이더 목록 조회
+    모델 제공자 조회
 
-    등록 가능한 모델 프로바이더 목록을 조회합니다.
-    페이지네이션을 지원합니다.
+    등록 가능한 모델 제공자 목록을 조회하거나, 이름으로 특정 제공자를 조회합니다.
+
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+    - **provider_name** (str, optional): 조회할 모델 제공자 이름
+        - 제공 시: 해당 이름이 포함된 제공자만 반환 (게이트웨이에서 부분 일치 필터)
+        - 생략 시: 전체 모델 제공자 목록 반환
+        - 예: "huggingface", "ollama", "custom" 등
+
+    ## Response (WrappedList)
+    MLOps 원본은 `ModelProviderReadSchema` 단일 객체 또는 목록을 반환하지만,
+    게이트웨이는 프론트 계약에 따라 `{data, total, page, size}` 래퍼로 반환:
+    - **data** (List[ModelProviderReadSchema]): 제공자 목록
+        - id (int): 모델 제공자 ID
+        - name (str): 모델 제공자 이름
+        - description (str): 모델 제공자 설명
+    - **total** (int): 필터 조건에 맞는 전체 제공자 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
+
+    ## Notes
+    - `provider_name` 필터는 게이트웨이에서 부분 일치(lowercase `in` 비교)로 처리
+    - 조회된 `id` 값은 `POST /models` 의 `provider_id` 파라미터에 사용
+    - 하드코딩된 숫자 값 대신 반드시 이 API로 조회한 `id`를 사용할 것
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     try:
         all_providers_data = await model_service.get_model_providers(
@@ -512,10 +694,37 @@ async def get_model_types(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    모델 타입 목록 조회
+    모델 타입 조회
 
-    등록 가능한 모델 타입 목록을 조회합니다.
-    페이지네이션을 지원합니다.
+    등록 가능한 모델 타입 목록을 조회하거나, 이름으로 특정 타입을 조회합니다.
+
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+    - **type_name** (str, optional): 조회할 모델 타입 이름
+        - 제공 시: 해당 이름이 포함된 타입만 반환 (게이트웨이에서 부분 일치 필터)
+        - 생략 시: 전체 모델 타입 목록 반환
+        - 예: "Object Detection Model", "Fine-tuned Model" 등
+
+    ## Response (WrappedList)
+    MLOps 원본은 `ModelTypeReadSchema` 단일 객체 또는 목록을 반환하지만,
+    게이트웨이는 프론트 계약에 따라 `{data, total, page, size}` 래퍼로 반환:
+    - **data** (List[ModelTypeReadSchema]): 타입 목록
+        - id (int): 모델 타입 ID
+        - name (str): 모델 타입 이름
+        - description (str): 모델 타입 설명
+    - **total** (int): 필터 조건에 맞는 전체 타입 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
+
+    ## Notes
+    - `type_name` 필터는 게이트웨이에서 부분 일치(lowercase `in` 비교)로 처리
+    - 조회된 `id` 값은 `POST /models` 의 `type_id` 파라미터에 사용
+    - 하드코딩된 숫자 값 대신 반드시 이 API로 조회한 `id`를 사용할 것
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     try:
         all_types_data = await model_service.get_model_types(
@@ -568,10 +777,37 @@ async def get_model_formats(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    모델 포맷 목록 조회
+    모델 포맷 조회
 
-    등록 가능한 모델 포맷 목록을 조회합니다.
-    페이지네이션을 지원합니다.
+    등록 가능한 모델 포맷 목록을 조회하거나, 이름으로 특정 포맷을 조회합니다.
+
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작, 기본값 1)
+    - **size** (int, optional): 페이지당 항목 수 (1-100, 기본값 20)
+    - **format_name** (str, optional): 조회할 모델 포맷 이름
+        - 제공 시: 해당 이름이 포함된 포맷만 반환 (게이트웨이에서 부분 일치 필터)
+        - 생략 시: 전체 모델 포맷 목록 반환
+        - 예: "transformers", "sentence-transformers", "gguf", "bge-m3" 등
+
+    ## Response (WrappedList)
+    MLOps 원본은 `ModelFormatReadSchema` 단일 객체 또는 목록을 반환하지만,
+    게이트웨이는 프론트 계약에 따라 `{data, total, page, size}` 래퍼로 반환:
+    - **data** (List[ModelFormatReadSchema]): 포맷 목록
+        - id (int): 모델 포맷 ID
+        - name (str): 모델 포맷 이름
+        - description (str): 모델 포맷 설명
+    - **total** (int): 필터 조건에 맞는 전체 포맷 수
+    - **page** (int): 요청한 페이지 번호
+    - **size** (int): 요청한 페이지 크기
+
+    ## Notes
+    - `format_name` 필터는 게이트웨이에서 부분 일치(lowercase `in` 비교)로 처리
+    - 조회된 `id` 값은 `POST /models` 의 `format_id` 파라미터에 사용
+    - 하드코딩된 숫자 값 대신 반드시 이 API로 조회한 `id`를 사용할 것
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     try:
         # format_name 없이 전체 데이터 가져오기
@@ -615,6 +851,177 @@ async def get_model_formats(
             detail=f"Failed to get model formats: {str(e)}"
         )
 
+@router.post("/auto-generate")
+async def auto_generate_model(
+        model_key: str = Query(..., description="등록할 사전 정의 모델 키"),
+        db: Session = Depends(get_db),
+        current_user: Member = Depends(get_current_user)
+):
+    """
+    사전 정의 모델 자동 등록
+
+    사전 정의된 모델 목록에서 선택하여 자동으로 등록합니다.
+    `POST /api/v1/models`와 동일한 등록 프로세스를 수행하되,
+    모델의 provider, type, format 등의 메타 정보가 MLOps 내부에서 자동으로 설정됩니다.
+
+    ## Query Parameters
+    - **model_key** (str, required): 등록할 사전 정의 모델 키
+        - `hustvl/yolos-tiny`: YOLOS Tiny (object-detection, HuggingFace, pytorch)
+        - `hustvl/yolos-small`: YOLOS Small (object-detection, HuggingFace, pytorch)
+        - `facebook/detr-resnet-50`: DETR ResNet-50 (object-detection, HuggingFace, pytorch)
+        - `facebook/detr-resnet-101`: DETR ResNet-101 (object-detection, HuggingFace, pytorch)
+        - `ahmgam/medllama3-v20:latest`: MedLlama3 (text-generation, Ollama, gguf)
+        - `bge-m3`: BGE-M3 Embedding (embedding, Ollama, gguf)
+        - `yolox_s`: YOLOX-S (object-detection, Custom, yolox) — 가중치 자동 다운로드
+        - `yolox_m`: YOLOX-M (object-detection, Custom, yolox) — 가중치 자동 다운로드
+        - `qwq:32b`: QwQ-32B (text-generation, Ollama, gguf)
+        - `qwen3:32b`: Qwen3-32B (text-generation, Ollama, gguf)
+        - `qwen3:30b`: Qwen3-30B (text-generation, Ollama, gguf)
+        - `gpt-oss:20b`: GPT-OSS-20B (text-generation, Ollama, gguf)
+
+    ## Response (ModelBriefReadSchema)
+    `POST /api/v1/models`와 동일한 응답 형식
+    - **id** (int): 모델 고유 ID
+    - **name** (str): 모델 이름
+    - **description** (str, optional): 모델 설명
+    - **repo_id** (str, optional): 모델 저장소 ID
+    - **provider_info** / **type_info** / **format_info**: 각 메타 정보 (id/name/description)
+    - **parent_model_id** (int, optional): 부모 모델 ID
+    - **task** / **parameter** / **sample_code** (optional)
+    - **registry** (ModelRegistryReadSchema): 모델 레지스트리 정보
+    - **created_at** / **updated_at** (datetime)
+
+    게이트웨이는 MLOps 응답을 그대로 전달하며, 추가로 게이트웨이 DB에
+    사용자-모델 매핑을 생성합니다 (admin이 호출하면 카탈로그 모델로 분류).
+
+    ## Notes
+    - 각 모델의 provider_id, type_id, format_id는 MLOps DB에서 이름으로 자동 조회됩니다
+    - `bge-m3`는 Ollama Embedding 모델로, PVC 다운로드 및 자동 배포가 수행됩니다
+    - `yolox_s`, `yolox_m`은 GitHub에서 가중치 파일(.pth)을 자동 다운로드하여 MLflow에 등록합니다
+    - MLOps에는 등록되었으나 게이트웨이 DB 매핑 저장에 실패하는 경우 경고만 기록하고 MLOps 응답은 그대로 반환됩니다
+
+    ## Errors
+    - **400**: 모델 키에 해당하는 provider/type/format을 MLOps DB에서 찾을 수 없음
+    - **401**: 인증되지 않은 사용자
+    - **422**: 유효하지 않은 model_key
+    - **500**: 모델 등록 중 서버 내부 오류 (가중치 다운로드 실패 포함)
+    """
+    try:
+        user_info = {
+            'member_id': current_user.member_id,
+            'role': current_user.role,
+            'name': current_user.name,
+        }
+
+        created = await model_service.auto_generate_model(
+            model_key=model_key, user_info=user_info
+        )
+
+        # 게이트웨이 DB에 사용자-모델 매핑 저장
+        try:
+            is_catalog = current_user.role.lower() == 'admin'
+            model_crud.create_model_mapping(
+                db=db,
+                surro_model_id=created.get('id'),
+                member_id=current_user.member_id,
+                model_name=created.get('name', model_key),
+                is_catalog=is_catalog,
+            )
+            logger.info(
+                f"Auto-generated model mapping saved: surro_id={created.get('id')}, "
+                f"member_id={current_user.member_id}, is_catalog={is_catalog}"
+            )
+        except Exception as mapping_error:
+            logger.warning(
+                f"Model {created.get('id')} auto-generated in MLOps but mapping failed: {mapping_error}"
+            )
+
+        return created
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error auto-generating model ({model_key}) for {current_user.member_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to auto-generate model: {str(e)}"
+        )
+
+
+@router.put("/base-deployments/{model_id}/status")
+async def update_model_base_deployment_status(
+        model_id: int = Path(..., description="모델 ID"),
+        service_name: str = Form(...),
+        service_hostname: str = Form(...),
+        deployment_status: str = Form(..., alias="status"),
+        internal_url: Optional[str] = Form(None),
+        error_message: Optional[str] = Form(None),
+        current_user: Member = Depends(get_current_user)
+):
+    """
+    모델 기본 배포 상태 업데이트 (백엔드 서버 내부 전용 API)
+
+    **⚠️ 경고: 이 API는 백엔드 서버 내부에서만 사용하는 내부 API입니다.**
+    **프론트엔드나 외부 클라이언트에서 직접 호출해서는 안 됩니다.**
+
+    Kubeflow 파이프라인 컴포넌트에서 배포 상태를 업데이트하기 위한 엔드포인트입니다.
+    파이프라인 컴포넌트 내부에서 인증 토큰을 발급받아 사용합니다.
+    게이트웨이는 호환성 유지를 위해 MLOps로 그대로 프록시합니다.
+
+    ## 사용 목적
+    - Kubeflow 파이프라인 컴포넌트에서 모델 배포 상태를 DB에 업데이트하기 위해 사용
+    - 백엔드 서버 내부 시스템 간 통신용으로만 사용
+
+    ## Path Parameters
+    - **model_id** (int): 모델 ID
+
+    ## Request Body (Form Data)
+    - **service_name** (str, required): 서비스 이름
+    - **service_hostname** (str, required): 서비스 호스트명
+    - **status** (str, required): 배포 상태 ("deployed", "deploying", "failed")
+    - **internal_url** (str, optional): 내부 접근 URL
+    - **error_message** (str, optional): 오류 메시지 (실패 시)
+
+    ## Response
+    - **success** (bool): 업데이트 성공 여부
+    - **message** (str): 결과 메시지
+
+    ## Notes
+    - **내부 API**: 백엔드 서버 내부에서만 사용하는 API입니다
+    - **호출 주체**: Kubeflow 파이프라인 컴포넌트에서만 호출됩니다
+    - **인증**: 인증 토큰이 필요하며, 파이프라인 컴포넌트에서 자동으로 발급받아 사용합니다
+    - **프론트엔드 사용 금지**: 프론트엔드나 외부 클라이언트에서 직접 호출하지 마세요
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 배포 정보를 찾을 수 없음
+    - **500**: 서버 내부 오류
+    """
+    try:
+        user_info = {
+            'member_id': current_user.member_id,
+            'role': current_user.role,
+            'name': current_user.name,
+        }
+        return await model_service.update_base_deployment_status(
+            model_id=model_id,
+            service_name=service_name,
+            service_hostname=service_hostname,
+            deployment_status=deployment_status,
+            internal_url=internal_url,
+            error_message=error_message,
+            user_info=user_info,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating base deployment status for model {model_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to update base deployment status: {str(e)}"
+        )
+
+
 @router.get("/{model_id}", response_model=ModelResponse)
 async def get_model(
     model_id: int = Path(..., description="조회할 모델 ID"),
@@ -622,17 +1029,61 @@ async def get_model(
         current_user: Member = Depends(get_current_user)
 ):
     """
-    모델 상세 조회
+    모델 상세정보 조회
 
     특정 모델의 상세 정보를 조회합니다.
+    제공자, 타입, 포맷 정보와 부모/자식 모델 관계를 포함하여 반환합니다.
+
+    게이트웨이 권한 검사: 본인 소유 모델 또는 카탈로그 모델만 조회 가능.
+    접근 권한이 없는 경우 404로 응답합니다.
 
     ## Path Parameters
+    - **model_id** (int): 조회할 모델 ID
 
-    - **model_id**: 조회할 모델 ID
+    ## Response (ModelReadSchema)
+    - **id** (int): 모델 고유 ID
+    - **name** (str): 모델 이름
+    - **description** (str, optional): 모델 설명
+    - **repo_id** (str, optional): 모델 저장소 ID
+    - **provider_info** (ModelProviderReadSchema): 모델 제공자 정보
+        - id (int): 제공자 ID
+        - name (str): 제공자 이름
+        - description (str): 제공자 설명
+    - **type_info** (ModelTypeReadSchema): 모델 타입 정보
+        - id / name / description
+    - **format_info** (ModelFormatReadSchema): 모델 포맷 정보
+        - id / name / description
+    - **parent_model_id** (int, optional): 부모 모델 ID
+        - 파인튜닝된 모델인 경우 원본 모델 ID
+    - **task** (str, optional): 모델 태스크
+    - **parameter** (str, optional): 모델 파라미터
+    - **sample_code** (str, optional): 샘플 코드
+    - **registry** (ModelRegistryReadSchema): 모델 레지스트리 정보
+        - id (int): 레지스트리 ID
+        - artifact_path (str): 아티팩트 경로
+        - uri (str): 모델 URI
+        - run_id (str, optional): MLflow 실행 ID
+        - reference_model_id (int): 참조 모델 ID
+        - created_at / updated_at (datetime)
+    - **parent_model** (ModelReadParentSchema, optional): 부모 모델 정보
+        - id / name / description
+        - parent_model (ModelReadParentSchema, optional): 상위 부모 모델 (재귀적)
+    - **child_models** (List[ModelReadChildSchema], optional): 자식 모델 목록
+        - id / name / description
+        - child_models (List[ModelReadChildSchema], optional): 하위 자식 모델 (재귀적)
+    - **created_at** (datetime): 모델 생성 시각
+    - **updated_at** (datetime): 모델 수정 시각
 
     ## Notes
+    - 모델의 모든 관련 정보(제공자, 타입, 포맷, 레지스트리)를 포함하여 반환
+    - 부모/자식 모델 관계는 재귀적으로 조회
+    - 게이트웨이는 접근 권한 체크 후 MLOps 응답을 그대로 전달
 
-    - 모델이 존재하지 않으면 404 오류를 반환합니다.
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 모델을 찾을 수 없거나 접근 권한이 없음
+        - 본인 소유 모델도 아니고 카탈로그 모델도 아닌 경우
+    - **500**: 서버 내부 오류
     """
     try:
         # 1. 사용자가 해당 모델을 소유하고 있는지 확인
@@ -688,15 +1139,33 @@ async def delete_model(
     """
     모델 삭제
 
-    특정 모델을 삭제합니다.
+    모델을 삭제합니다. 참조 관계를 확인하여 안전하게 삭제합니다.
+    다른 엔티티에서 참조되고 있는 경우 삭제할 수 없습니다.
+
+    게이트웨이 권한 검사: 본인 소유 모델만 삭제 가능 (카탈로그 모델 삭제 불가).
 
     ## Path Parameters
+    - **model_id** (int): 삭제할 모델 ID
 
-    - **model_id**: 삭제할 모델 ID
+    ## Response
+    - **message** (str): 삭제 결과 메시지 (예: "Model {model_id} deleted successfully")
+
+    MLOps 원본은 `{success: bool, message: str}`을 반환하지만, 게이트웨이는
+    MLOps 삭제 성공 후 게이트웨이 DB 매핑도 함께 삭제하고 `message`만 포함하여 응답합니다.
 
     ## Notes
+    - 모델이 다음 엔티티에서 참조되고 있으면 삭제할 수 없습니다:
+        - Experiment (실험)
+        - WorkflowComponent (워크플로우 컴포넌트)
+        - 다른 모델의 parent_model (자식 모델)
+    - 참조 관계가 있는 경우 MLOps에서 400 에러를 반환
+    - 삭제 성공 시 게이트웨이 DB의 사용자-모델 매핑도 제거됨
 
-    - 모델이 존재하지 않으면 404 오류를 반환합니다.
+    ## Errors
+    - **400**: 모델이 다른 엔티티에서 참조되고 있어 삭제할 수 없음 (MLOps 원본 에러 전달)
+    - **401**: 인증되지 않은 사용자
+    - **404**: 모델을 찾을 수 없거나 접근 권한이 없음 (본인 소유가 아님)
+    - **500**: 모델 삭제 중 서버 내부 오류
     """
     try:
         # 1. 사용자가 해당 모델을 소유하고 있는지 확인

--- a/app/routes/pipeline.py
+++ b/app/routes/pipeline.py
@@ -1,28 +1,46 @@
-from fastapi import APIRouter, Depends, HTTPException, status, Path
-from sqlalchemy.orm import Session
 import logging
 
-from app.database import get_db
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from sqlalchemy.orm import Session
+
 from app.auth import get_current_user
 from app.cruds import experiment_crud
+from app.database import get_db
+from app.models import Member
 from app.schemas.pipeline import (
-    TrainingPipelineRequest, TrainingPipelineResponse,
-    ModelRegistrationRequest, ModelRegistrationResponse,
-    TrainingStatusResponse
+    ModelRegistrationRequest,
+    ModelRegistrationResponse,
+    TrainingPipelineRequest,
+    TrainingPipelineResponse,
+    TrainingStatusResponse,
 )
 from app.services.pipeline_service import pipeline_service
-from app.models import Member
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/pipeline", tags=["Pipeline"])
 
+# NOTE:
+# This file is kept as a reference for the legacy gateway route design only.
+# The gateway no longer exposes /api/v1/pipeline/* publicly. Public learning
+# APIs are exposed only through /api/v1/learning/* in app.main.
+#
+# External MLOps still uses the legacy /pipeline endpoints for training creation
+# and model registration. The gateway keeps these routes public because
+# POST /pipeline/training is still where the external experiment_id is created.
+# That experiment_id must be stored in the gateway experiments mapping table so
+# the unified /learning domain can later enforce ownership and serve list/detail
+# APIs consistently.
+#
+# If another developer re-enables this router in app.main, they are restoring
+# a backward-compatibility alias, not the primary public API contract.
 
-@router.post("/training", response_model=TrainingPipelineResponse)
+
+@router.post("/training", response_model=TrainingPipelineResponse, summary="Container Train")
 async def submit_training(
-        request: TrainingPipelineRequest,
-        db: Session = Depends(get_db),
-        current_user: Member = Depends(get_current_user)
+    request: TrainingPipelineRequest,
+    db: Session = Depends(get_db),
+    current_user: Member = Depends(get_current_user),
 ):
     """
     학습 파이프라인 생성 및 실행
@@ -30,40 +48,30 @@ async def submit_training(
     모델과 데이터셋을 사용하여 Kubeflow Pipeline 기반의 학습 파이프라인을 생성하고 실행합니다.
     요청은 전체 Body(JSON)로 통일되며, 학습 시작 후 백그라운드에서 MLflow 메트릭 폴링이 시작됩니다.
 
-    ## Request Body (application/json) — `TrainingRequest`
+    ## Response (TrainingPipelineResponse)
+    - **experiment_id** (int | null): 생성된 학습 ID
 
-    | 필드 | 타입 | 필수 | 기본값 | 설명 |
-    |------|------|------|--------|------|
-    | `model_id` | integer | ✅ | — | 학습에 사용할 모델 ID |
-    | `dataset_id` | integer | ✅ | — | 학습에 사용할 데이터셋 ID |
-    | `train_name` | string | — | `""` | 학습 실험 이름 |
-    | `description` | string | — | `""` | 학습 실험 설명 |
-    | `gpus` | string | — | `"1"` | 사용할 GPU 개수 |
-    | `batch_size` | string | — | `"32"` | 배치 크기 |
-    | `epochs` | string | — | `"5"` | 학습 에포크 수 |
-    | `save_period` | string | — | `"1"` | 모델 저장 주기 (에포크 단위) |
-    | `weight_decay` | string | — | `"5e-4"` | 가중치 감쇠 계수 |
-    | `lr0` | string | — | `"0.01"` | 초기 학습률 |
-    | `lrf` | string | — | `"0.05"` | 최종 학습률 |
+    ## Notes
+    - 외부 MLOps에는 기존 `/pipeline/training` API로 요청합니다.
+    - 이 API는 새 `experiment_id`를 생성하는 진입점이므로 게이트웨이에서도 계속 유지합니다.
+    - 학습 생성 성공 시 게이트웨이 DB의 `experiments` 매핑 테이블에 사용자 소유권 정보를 저장합니다.
+    - 생성 이후의 목록/상세/수정/삭제는 `/api/v1/learning` 도메인 사용을 권장합니다.
 
-    ## Response (200)
-
-    | 필드 | 타입 | 설명 |
-    |------|------|------|
-    | `experiment_id` | integer \\| null | 생성된 실험의 고유 ID |
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 422: 요청 본문 검증 실패
+    - 500: 서버 내부 오류
     """
     try:
-        # 외부 API에 학습 파이프라인 제출
         result = await pipeline_service.submit_training(
             data=request.model_dump(),
             user_info={
-                'member_id': current_user.member_id,
-                'role': current_user.role,
-                'name': current_user.name
-            }
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
         )
 
-        # Gateway DB에 실험 매핑 저장
         experiment_id = result.get("experiment_id")
         if experiment_id:
             try:
@@ -74,9 +82,11 @@ async def submit_training(
                     name=request.train_name,
                     description=request.description,
                     model_id=request.model_id,
-                    dataset_id=request.dataset_id
+                    dataset_id=request.dataset_id,
                 )
-                logger.info(f"Created experiment mapping: surro_id={experiment_id}, member_id={current_user.member_id}")
+                logger.info(
+                    f"Created experiment mapping: surro_id={experiment_id}, member_id={current_user.member_id}"
+                )
             except Exception as mapping_error:
                 logger.warning(f"Failed to create experiment mapping: {str(mapping_error)}")
 
@@ -88,45 +98,45 @@ async def submit_training(
         logger.error(f"Error submitting training for user {current_user.member_id}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to submit training: {str(e)}"
+            detail=f"Failed to submit training: {str(e)}",
         )
 
 
-@router.post("/model/registration", response_model=ModelRegistrationResponse)
+@router.post("/model/registration", response_model=ModelRegistrationResponse, summary="Register Model")
 async def register_model(
-        request: ModelRegistrationRequest,
-        current_user: Member = Depends(get_current_user)
+    request: ModelRegistrationRequest,
+    current_user: Member = Depends(get_current_user),
 ):
     """
-    학습 완료된 모델 등록 파이프라인 실행
+    학습 완료 모델 등록 파이프라인 실행
 
-    Query Parameter → Body(JSON) 변경. 응답이 객체로 확장되었으며,
-    KFP run_id를 DB에 저장하고 백그라운드에서 등록 상태 폴링이 시작됩니다.
+    학습이 완료된 모델을 등록하는 파이프라인을 실행합니다.
+    기존 Query Parameter 방식이 아닌 Body(JSON) 기반 요청이며, 응답은 객체 형태로 반환됩니다.
+    KFP run_id를 저장하고 백그라운드에서 등록 상태 폴링이 시작됩니다.
 
-    ## Request Body (application/json) — `ModelRegistrationRequest`
+    ## Response (ModelRegistrationResponse)
+    - **accepted** (bool): 파이프라인 접수 여부
+    - **experiment_id** (int): 대상 학습 ID
+    - **message** (str): 처리 결과 메시지
 
-    | 필드 | 타입 | 필수 | 설명 |
-    |------|------|------|------|
-    | `model_name` | string | ✅ | 등록될 모델 표시 이름 |
-    | `description` | string | ✅ | 모델 설명 |
-    | `experiment_id` | integer | ✅ | 대상 학습 실험 ID |
+    ## Notes
+    - 외부 MLOps에는 기존 `/pipeline/model/registration` API로 요청합니다.
+    - 생성된 학습의 후속 등록 단계이므로 legacy `pipeline` 도메인에 유지합니다.
+    - 학습 목록 및 상세 조회는 `/api/v1/learning` 사용을 권장합니다.
 
-    ## Response (200) — `ModelRegistrationResponse`
-
-    | 필드 | 타입 | 설명 |
-    |------|------|------|
-    | `accepted` | boolean | 파이프라인 제출 수락 여부 |
-    | `experiment_id` | integer | 요청 실험 ID |
-    | `message` | string | 안내 메시지 |
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 422: 요청 본문 검증 실패
+    - 500: 서버 내부 오류
     """
     try:
         result = await pipeline_service.register_model(
             data=request.model_dump(),
             user_info={
-                'member_id': current_user.member_id,
-                'role': current_user.role,
-                'name': current_user.name
-            }
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
         )
         return result
 
@@ -136,53 +146,63 @@ async def register_model(
         logger.error(f"Error registering model for user {current_user.member_id}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to register model: {str(e)}"
+            detail=f"Failed to register model: {str(e)}",
         )
 
 
-@router.get("/training/{experiment_id}/status", response_model=TrainingStatusResponse, deprecated=True)
+@router.get(
+    "/training/{experiment_id}/status",
+    response_model=TrainingStatusResponse,
+    deprecated=True,
+    summary="Get Training Status",
+)
 async def get_training_status(
-        experiment_id: int = Path(..., description="실험 ID"),
-        current_user: Member = Depends(get_current_user)
+    experiment_id: int = Path(..., description="학습 ID"),
+    current_user: Member = Depends(get_current_user),
 ):
     """
     학습 상태 조회 (Deprecated)
 
-    @deprecated — GET /api/v1/experiments/{experiment_id} 사용 권장.
+    @deprecated — `GET /api/v1/learning/{experiment_id}` 또는 기존 `GET /api/v1/experiments/{experiment_id}` 사용 권장.
 
-    기존 Path Parameter 방식의 학습 상태 조회. 하위 호환을 위해 유지합니다.
+    기존 Path Parameter 방식의 학습 상태 조회입니다.
+    하위 호환을 위해 유지하지만, 신규 연동에서는 learning 상세 조회 API 사용을 권장합니다.
 
-    ## Path Parameter
+    ## Path Parameters
+    - **experiment_id** (int): 학습 ID
 
-    | 필드 | 타입 | 설명 |
-    |------|------|------|
-    | `experiment_id` | integer | 실험 ID |
+    ## Response (TrainingStatusResponse)
+    - **status** (str): 학습 상태
+    - **start_time** (int): 시작 시각 (Unix timestamp)
+    - **end_time** (int | null): 종료 시각 (Unix timestamp)
+    - **elapsed_time** (int): 경과 시간 (초)
+    - **max_epoch** (int): 최대 epoch 수
+    - **current_epoch** (int): 현재 epoch
+    - **loss_history** (array): loss 이력
+    - **epoch_history** (array): epoch 이력
+    - **average_precision_50_history** (array): AP@50 이력
+    - **average_precision_75_history** (array): AP@75 이력
+    - **best_average_precision_history** (array): Best AP 이력
+    - **average_precision_50_95_history** (array): AP@50:95 이력
 
-    ## Response (200) — `TrainingStatusResponse`
+    ## Notes
+    - 외부 MLOps에는 기존 `/pipeline/training/{experiment_id}/status` API로 요청합니다.
+    - 이 경로는 하위 호환 전용입니다.
+    - 신규 화면/연동은 `/api/v1/learning/{experiment_id}` 사용을 권장합니다.
 
-    | 필드 | 타입 | 필수 | 설명 |
-    |------|------|------|------|
-    | `status` | string | ✅ | 학습 상태 |
-    | `start_time` | integer | ✅ | 시작 시간 (Unix timestamp) |
-    | `end_time` | integer \\| null | — | 종료 시간 (Unix timestamp) |
-    | `elapsed_time` | integer | ✅ | 경과 시간 (초) |
-    | `max_epoch` | integer | ✅ | 최대 에포크 수 |
-    | `current_epoch` | integer | ✅ | 현재 에포크 |
-    | `loss_history` | array | ✅ | 손실 히스토리 |
-    | `epoch_history` | array | ✅ | 에포크 히스토리 |
-    | `average_precision_50_history` | array | ✅ | AP@50 히스토리 |
-    | `average_precision_75_history` | array | ✅ | AP@75 히스토리 |
-    | `best_average_precision_history` | array | ✅ | Best AP 히스토리 |
-    | `average_precision_50_95_history` | array | ✅ | AP@50:95 히스토리 |
+    ## Errors
+    - 401: 인증되지 않은 사용자
+    - 404: 학습을 찾을 수 없음
+    - 500: 서버 내부 오류
     """
     try:
         result = await pipeline_service.get_training_status(
             experiment_id=experiment_id,
             user_info={
-                'member_id': current_user.member_id,
-                'role': current_user.role,
-                'name': current_user.name
-            }
+                "member_id": current_user.member_id,
+                "role": current_user.role,
+                "name": current_user.name,
+            },
         )
         return result
 
@@ -192,5 +212,5 @@ async def get_training_status(
         logger.error(f"Error getting training status: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get training status: {str(e)}"
+            detail=f"Failed to get training status: {str(e)}",
         )

--- a/app/routes/workflow.py
+++ b/app/routes/workflow.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from typing import Optional
 from app.database import get_db
 from app.cruds.workflow import workflow_crud
+from app.models.member import Member
 from app.auth import get_current_user
 from app.schemas.workflow import (
     WorkflowCreateRequest,
@@ -31,18 +32,35 @@ async def get_component_types(
     """
     사용 가능한 컴포넌트 타입 조회
 
-    워크플로우 구성에 사용할 수 있는 컴포넌트 타입 목록을 조회합니다. 각 타입별로 고유한 component_id와 설명을 제공하여 워크플로우 정의 시 활용할 수 있습니다.
+    워크플로우 구성에 사용할 수 있는 컴포넌트 타입 목록을 조회합니다.
+    각 타입별로 고유한 component_id와 설명을 제공하여 워크플로우 정의 시 활용할 수 있습니다.
 
-    ## Usage Example
-    1. 이 API로 사용 가능한 컴포넌트 타입 확인
-    2. workflow_definition 작성 시 component_id 사용
-    3. 각 컴포넌트 타입에 맞는 설정 적용
+    ## Response (List[ComponentTypeInfo])
+    각 항목은 다음 필드를 포함:
+    - **type** (str): 컴포넌트 타입
+        - "START": 워크플로우 시작점
+        - "END": 워크플로우 종료점
+        - "MODEL": ML 모델 실행 노드
+        - "KNOWLEDGE_BASE": 지식 베이스 검색 노드
+    - **component_id** (str): 컴포넌트 식별자
+        - 워크플로우 정의 시 사용할 고유 ID
+        - 일반적으로 type과 동일 (예: "START", "END", "MODEL", "KNOWLEDGE_BASE")
+    - **name** (str): 타입 표시명 (한글)
+        - "시작 노드", "종료 노드", "모델 노드", "지식 베이스 노드" 등
+    - **description** (str): 타입 설명
+        - 각 컴포넌트 타입의 역할과 용도 설명
+
+    게이트웨이는 MLOps 응답을 `{ "data": [...] }` 형태로 래핑하여 반환합니다.
 
     ## Notes
     - 고정된 타입 목록 반환 (동적 변경 없음)
     - 워크플로우는 반드시 START로 시작하고 END로 종료
     - MODEL 타입은 model_id 필수, prompt_id 선택
     - KNOWLEDGE_BASE 타입은 knowledge_base_id 필수
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
     """
     user_info = {
         'member_id': current_user.member_id,
@@ -68,14 +86,16 @@ async def create_workflow(
     """
     새로운 워크플로우 생성 (직접 생성)
 
-    워크플로우를 직접 정의하여 생성합니다. 템플릿으로부터 생성하려면 /workflows/templates/{template_id}/clone API를 사용하세요. 생성된 워크플로우는 DRAFT 상태로 시작하며, execute API를 통해 실행할 수 있습니다.
+    워크플로우를 직접 정의하여 생성합니다.
+    템플릿으로부터 생성하려면 `/workflows/templates/{template_id}/clone` API를 사용하세요.
+    생성된 워크플로우는 DRAFT 상태로 시작하며, execute API를 통해 실행할 수 있습니다.
 
     ## Request Body (WorkflowCreateRequest)
-    - name (str, required): 워크플로우 이름
-    - description (str, optional): 워크플로우 설명
-    - category (str, optional): 카테고리 (분류용)
-    - service_id (str, optional): 연결할 서비스 ID
-    - workflow_definition (WorkflowDefinition, optional): 워크플로우 정의
+    - **name** (str, required): 워크플로우 이름
+    - **description** (str, optional): 워크플로우 설명
+    - **category** (str, optional): 카테고리 (분류용)
+    - **service_id** (str, optional): 연결할 서비스 ID
+    - **workflow_definition** (WorkflowDefinition, optional): 워크플로우 정의
         - components (List[ComponentCreateRequest]): 컴포넌트 목록
             - name (str): 컴포넌트 이름
             - type (ComponentType): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
@@ -86,13 +106,44 @@ async def create_workflow(
             - source_component_type (ComponentType): 소스 컴포넌트 타입
             - target_component_type (ComponentType): 타겟 컴포넌트 타입
 
+    ## Response (WorkflowResponse)
+    - **id** (int): 게이트웨이 DB PK
+    - **surro_workflow_id** (str): MLOps 워크플로우 UUID
+    - **created_at** (datetime): 게이트웨이 DB 기준 생성 시각
+    - **updated_at** (datetime): 게이트웨이 DB 기준 수정 시각
+    - **created_by** (str): 게이트웨이 사용자 member_id
+    - **name** (str): 워크플로우 이름
+    - **description** (str): 워크플로우 설명
+    - **category** (str): 워크플로우 카테고리
+    - **status** (str): 워크플로우 상태
+        - "DRAFT": 임시저장 상태 (아직 실행되지 않음)
+        - "ACTIVE": 활성 상태 (배포 완료, 실행 가능)
+        - "ERROR": 오류 발생 상태 (실행 실패 또는 배포 오류)
+    - **service_id** (str): 연결된 서비스 ID
+        - 모니터링 및 서비스 관리용 서비스 ID
+        - null 가능 (서비스 연결 없이도 워크플로우 생성 가능)
+    - **is_template** (bool): 템플릿 여부
+        - false: 일반 워크플로우
+        - true: 템플릿 (템플릿 조회 API 사용 권장)
+    - **template_id** (str): 원본 템플릿 ID
+        - 직접 생성한 경우 항상 null
+        - 템플릿으로부터 생성된 경우 `/workflows/templates/{template_id}/clone` API 사용
+
+    (MLOps 원본 응답의 `creator_id`(int)는 MLOps 슈퍼어드민 ID로, 게이트웨이에서는
+     사용자 매핑을 위해 DB의 `created_by`(member_id, str)로 대체하여 반환)
+
     ## Notes
-    - 템플릿으로부터 생성하려면 /workflows/templates/{template_id}/clone API 사용
+    - 템플릿으로부터 생성하려면 `/workflows/templates/{template_id}/clone` API 사용
     - MODEL 컴포넌트는 유효한 model_id 필요, prompt_id는 선택
     - KNOWLEDGE_BASE 컴포넌트는 유효한 knowledge_base_id 필요
     - 생성 직후 상태는 DRAFT
-    - is_template은 항상 false로 설정됨 (템플릿 생성은 /workflows/templates API 사용)
-    - 상세 정보(components, connections, creator 등)는 GET /workflows/{workflow_id}로 조회 가능
+    - is_template은 항상 false로 설정됨 (템플릿 생성은 `/workflows/templates` API 사용)
+    - 상세 정보(components, connections, creator 등)는 `GET /workflows/{workflow_id}`로 조회 가능
+
+    ## Errors
+    - **400**: 잘못된 요청 (정의 오류 등)
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류 (MLOps에는 생성됐으나 게이트웨이 DB 저장 실패 포함)
     """
     user_info = {
         'member_id': current_user.member_id,
@@ -157,95 +208,181 @@ async def create_workflow(
 @router.get("/", response_model=WorkflowListResponse)
 async def get_workflows(
         page: Optional[int] = Query(None, ge=1, description="페이지 번호 (1부터 시작)"),
-        size: Optional[int] = Query(None, ge=1, le=1000, description="페이지당 항목 수"),
-        search: Optional[str] = Query(None, description="검색어 (이름, 설명)"),
-        creator_id: Optional[str] = Query(None, description="생성자 ID 필터"),
+        size: Optional[int] = Query(None, ge=1, le=1000, description="페이지당 항목 수 (1-1000)"),
+        search: Optional[str] = Query(None, description="이름/설명 검색어 (게이트웨이 확장)"),
+        creator_id: Optional[str] = Query(None, description="생성자 member_id 필터 (게이트웨이 DB 기준)"),
+        service_id: Optional[str] = Query(None, description="서비스 ID 필터 (UUID)"),
         status: Optional[str] = Query(None, description="상태 필터 (DRAFT/ACTIVE/ERROR)"),
         db: Session = Depends(get_db),
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 목록 조회 (템플릿 제외)
+    워크플로우 목록 조회 (템플릿 제외)
 
-        생성된 워크플로우 목록을 조회합니다. 템플릿은 포함되지 않으며, 페이지네이션과 다양한 필터 옵션을 제공합니다.
+    생성된 워크플로우 목록을 조회합니다. 템플릿은 포함되지 않으며, 페이지네이션과 다양한 필터 옵션을 제공합니다.
 
-        ## Query Parameters
-        - page (int, optional): 페이지 번호 (1부터 시작)
-        - page_size (int, optional): 페이지당 항목 수 (1-1000)
-            - 페이지 파라미터 생략 시 전체 데이터 반환 (최대 10000개)
-        - creator_id (int, optional): 특정 사용자가 생성한 워크플로우만 필터
-        - service_id (int, optional): 특정 서비스에 연결된 워크플로우만 필터
-        - status (str, optional): 워크플로우 상태 필터
-            - "DRAFT": 임시저장 상태
-            - "ACTIVE": 활성 상태 (배포됨)
-            - "ERROR": 오류 상태
+    ## Query Parameters
+    - page (int, optional): 페이지 번호 (1부터 시작)
+    - size (int, optional): 페이지당 항목 수 (1-1000)
+        - 페이지 파라미터 생략 시 전체 데이터 반환 (최대 10000개)
+        - MLOps 원본의 `page_size`에 대응 — 게이트웨이-프론트 계약에 따라 `size`로 노출
+    - search (str, optional): 이름/설명 검색어 (게이트웨이 DB 기준 확장 기능, MLOps 원본에는 없음)
+    - creator_id (str, optional): 특정 사용자가 생성한 워크플로우만 필터
+        - MLOps 원본은 `int`이지만 MLOps는 슈퍼어드민 단일 계정으로 동작하므로,
+          게이트웨이 DB의 `created_by` (member_id, str) 기준으로 필터링
+    - service_id (str, optional): 특정 서비스에 연결된 워크플로우만 필터 (UUID, MLOps 필터)
+    - status (str, optional): 워크플로우 상태 필터 (MLOps 필터)
+        - "DRAFT": 임시저장 상태
+        - "ACTIVE": 활성 상태 (배포됨)
+        - "ERROR": 오류 상태
 
-        ## Notes
-        - 템플릿을 조회하려면 /workflows/templates API 사용
-        - 페이지네이션 생략 시 최대 10000개까지 반환
-        """
-    skip = None
-    limit = None
+    ## Response (WorkflowListResponse)
+    - total (int): 필터 조건에 맞는 전체 워크플로우 수
+    - page (int | null), size (int | null): 요청한 페이지네이션 값
+    - data (List[WorkflowResponse]): 워크플로우 목록
+        - id (int): 게이트웨이 DB PK
+        - surro_workflow_id (str): MLOps 워크플로우 UUID
+        - created_at (datetime): 게이트웨이 DB 기준 생성 시각
+        - updated_at (datetime): 게이트웨이 DB 기준 수정 시각
+        - created_by (str): 게이트웨이 사용자 member_id
+        - name (str): 워크플로우 이름
+        - description (str): 설명
+        - category (str): 카테고리
+        - status (str): 상태 (DRAFT/ACTIVE/ERROR)
+        - service_id (str): 연결된 서비스 ID
+        - is_template (bool): 템플릿 여부 (항상 false — 템플릿은 별도 API)
+        - template_id (str): 원본 템플릿 ID (복제된 경우)
 
-    if page is not None and size is not None:
-        skip = (page - 1) * size
-        limit = size
+    ## Notes
+    - 템플릿을 조회하려면 `/workflows/templates` API 사용
+    - 페이지네이션 생략 시 최대 10000개까지 반환
 
-    # DB에서 조회
-    workflows, total = workflow_crud.get_workflows(
-        db=db,
-        skip=skip,
-        limit=limit,
-        search=search,
-        creator_id=creator_id,
-        status=status
-    )
-
-    # 외부 API에서 각 워크플로우의 상세 정보 조회하여 병합
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
         'name': current_user.name
     }
 
-    response_data = []
-    for wf in workflows:
-        try:
-            external_wf = await workflow_service.get_workflow(wf.surro_workflow_id, user_info)
-            if external_wf:
-                response_data.append(
-                    WorkflowResponse(
-                        id=wf.id,
-                        surro_workflow_id=wf.surro_workflow_id,
-                        created_at=wf.created_at,
-                        updated_at=wf.updated_at,
-                        created_by=wf.created_by,
-                        name=external_wf.name,
-                        description=external_wf.description,
-                        category=external_wf.category,
-                        status=external_wf.status,
-                        service_id=external_wf.service_id,
-                        is_template=external_wf.is_template,
-                        template_id=external_wf.template_id
-                    )
+    # 1) MLOps 전체 목록 조회 (service_id, status 필터는 MLOps에서 처리)
+    #    - 페이지네이션은 동기화 + DB 필터 이후 게이트웨이에서 적용하므로 전체 조회
+    #    - creator_id는 MLOps 의미 없음(슈퍼어드민 단일) → 게이트웨이 DB에서 필터
+    external_list = await workflow_service.get_workflows(
+        page=None,
+        page_size=None,
+        creator_id=None,
+        service_id=service_id,
+        status=status,
+        user_info=user_info,
+    )
+
+    # 템플릿 제외 (이 엔드포인트는 템플릿 반환 안 함)
+    external_list = [w for w in external_list if not w.is_template]
+    external_by_id = {w.id: w for w in external_list}
+
+    # 2) DB ↔ MLOps 동기화
+    db_all, _ = workflow_crud.get_workflows(
+        db=db, skip=None, limit=None,
+        search=None, creator_id=None, status=None
+    )
+    db_surro_ids = {w.surro_workflow_id for w in db_all}
+
+    # 2a) MLOps에서 사라진 워크플로우는 DB에서 제거
+    #     (Workflow 모델에 soft-delete 컬럼이 없어 현재는 hard-delete)
+    for dbw in db_all:
+        if dbw.surro_workflow_id not in external_by_id:
+            try:
+                workflow_crud.delete_workflow_by_surro_id(
+                    db=db, surro_workflow_id=dbw.surro_workflow_id
                 )
-            else:
-                # 외부 API에서 해당 워크플로우를 찾지 못한 경우 (404)
-                logger.warning(f"Workflow {wf.surro_workflow_id} not found in external API, skipping")
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Error fetching workflow {wf.surro_workflow_id}: {str(e)}")
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=f"Failed to fetch workflow data from external API: {str(e)}"
+                logger.info(
+                    f"Removed orphan workflow from DB (not in MLOps): "
+                    f"surro_id={dbw.surro_workflow_id}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to remove orphan workflow {dbw.surro_workflow_id}: {e}"
+                )
+
+    # 2b) MLOps에만 있는 워크플로우는 admin 소유로 등록
+    missing = [w for w in external_list if w.id not in db_surro_ids]
+    if missing:
+        admin = db.query(Member).filter(
+            Member.role == "admin", Member.is_active == True
+        ).first()
+        if not admin:
+            logger.warning(
+                f"No active admin member found — skipping auto-registration "
+                f"for {len(missing)} workflow(s) discovered in MLOps"
             )
+        else:
+            for m in missing:
+                try:
+                    workflow_crud.create_workflow(
+                        db=db,
+                        name=m.name,
+                        description=m.description,
+                        created_by=admin.member_id,
+                        surro_workflow_id=m.id,
+                    )
+                    logger.info(
+                        f"Registered missing workflow under admin "
+                        f"({admin.member_id}): surro_id={m.id}"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to auto-register workflow {m.id}: {e}"
+                    )
+
+    # 3) 게이트웨이 DB 기준 필터 (creator_id, search)
+    db_filtered, _ = workflow_crud.get_workflows(
+        db=db,
+        skip=None, limit=None,
+        search=search,
+        creator_id=creator_id,
+        status=None,
+    )
+
+    # 4) MLOps 상세 데이터와 병합 (MLOps 응답에 없는 것은 제외 — status/service_id 필터 반영)
+    merged = []
+    for dbw in db_filtered:
+        ext = external_by_id.get(dbw.surro_workflow_id)
+        if not ext:
+            continue
+        merged.append(
+            WorkflowResponse(
+                id=dbw.id,
+                surro_workflow_id=dbw.surro_workflow_id,
+                created_at=dbw.created_at,
+                updated_at=dbw.updated_at,
+                created_by=dbw.created_by,
+                name=ext.name,
+                description=ext.description,
+                category=ext.category,
+                status=ext.status,
+                service_id=ext.service_id,
+                is_template=ext.is_template,
+                template_id=ext.template_id,
+            )
+        )
+
+    total = len(merged)
+
+    # 5) 게이트웨이 레벨 페이지네이션
+    if page is not None and size is not None:
+        start = (page - 1) * size
+        merged = merged[start:start + size]
+    else:
+        merged = merged[:10000]
 
     return WorkflowListResponse(
-        data=response_data,
+        data=merged,
         total=total,
         page=page,
-        size=size
+        size=size,
     )
 
 # ===== Template 관련 =====
@@ -256,33 +393,67 @@ async def create_template(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 템플릿 생성
+    워크플로우 템플릿 생성
 
-        재사용 가능한 워크플로우 템플릿을 생성합니다. 템플릿은 다른 사용자들이 복사하여 사용할 수 있는 기본 워크플로우 구조입니다.
+    재사용 가능한 워크플로우 템플릿을 생성합니다.
+    템플릿은 다른 사용자들이 복사하여 사용할 수 있는 기본 워크플로우 구조입니다.
 
-        ## Request Body (WorkflowTemplateCreateRequest)
-        - name (str, required): 템플릿 이름
-        - description (str, optional): 템플릿 설명
-        - category (str, optional): 템플릿 카테고리
-        - workflow_definition (WorkflowDefinition, required): 템플릿 구조
-            - components (List[ComponentCreateRequest]): 컴포넌트 정의
-                - name (str): 컴포넌트 이름
-                - type (str): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
-                - model_id (int, optional): MODEL 타입인 경우 모델 ID
-                - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
-                - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID
-            - connections (List[ConnectionCreateRequest]): 연결 정의
-                - source_component_id (str): 소스 컴포넌트 ID
-                - target_component_id (str): 타겟 컴포넌트 ID
+    ## Request Body (WorkflowTemplateCreateRequest)
+    - **name** (str, required): 템플릿 이름
+    - **description** (str, optional): 템플릿 설명
+    - **category** (str, optional): 템플릿 카테고리
+    - **workflow_definition** (WorkflowDefinition, required): 템플릿 구조
+        - components (List[ComponentCreateRequest]): 컴포넌트 정의
+            - name (str): 컴포넌트 이름
+            - type (str): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
+            - model_id (int, optional): MODEL 타입인 경우 모델 ID
+            - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
+            - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID
+        - connections (List[ConnectionCreateRequest]): 연결 정의
+            - source_component_id (str): 소스 컴포넌트 ID
+            - target_component_id (str): 타겟 컴포넌트 ID
 
-        ## Notes
-        - 템플릿은 실행할 수 없고 복사용만 가능
-        - 모든 사용자가 템플릿을 볼 수 있음
-        - is_template은 항상 true로 설정됨
-        - service_id는 항상 null로 설정됨 (템플릿은 서비스에 연결되지 않음)
-        - usage_count는 0으로 시작
-        - 상세 정보(components, connections 등)는 GET /workflows/templates/{template_id}로 조회 가능
-        """
+    ## Response (WorkflowTemplateBriefSchema)
+    - **id** (str): 템플릿 UUID
+    - **name** (str): 템플릿 이름
+    - **description** (str): 템플릿 설명
+    - **category** (str): 템플릿 카테고리
+    - **status** (str): 템플릿 상태 (DRAFT)
+    - **service_id** (str): 기본 서비스 ID
+    - **creator_id** (int): 템플릿 생성자 ID
+    - **creator** (UserSchema): 생성자 정보
+        - id (int): 사용자 ID
+        - username (str): 사용자명
+        - name (str): 사용자 이름
+        - password (str): 비밀번호 (해시된 값)
+        - created_at (datetime): 계정 생성 시각
+        - updated_at (datetime): 계정 정보 수정 시각
+        - created_by (str, optional): 계정 생성자
+        - updated_by (str, optional): 계정 정보 수정자
+    - **is_template** (bool): 템플릿 여부 (항상 true)
+    - **template_id** (str): 원본 템플릿 ID (null)
+    - **usage_count** (int): 템플릿 사용 횟수
+        - 템플릿을 복사하여 생성된 워크플로우의 총 개수
+        - 동적으로 계산됨 (실시간 반영)
+        - 생성 직후는 0
+    - **created_at** (datetime): 생성 시각
+    - **updated_at** (datetime): 수정 시각
+
+    (템플릿은 게이트웨이 DB에 매핑을 저장하지 않고 MLOps 응답을 그대로 전달합니다)
+
+    ## Notes
+    - 템플릿은 실행할 수 없고 복사용만 가능
+    - 모든 사용자가 템플릿을 볼 수 있음
+    - is_template은 항상 true로 설정됨
+    - service_id는 항상 null로 설정됨 (템플릿은 서비스에 연결되지 않음)
+    - usage_count는 0으로 시작
+    - 상세 정보(components, connections 등)는 `GET /workflows/templates/{template_id}`로 조회 가능
+
+    ## Errors
+    - **400**: 잘못된 워크플로우 정의
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -311,22 +482,55 @@ async def get_templates(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 템플릿 목록 조회
+    워크플로우 템플릿 목록 조회
 
-        사용 가능한 모든 워크플로우 템플릿을 조회합니다. 템플릿은 모든 사용자가 확인하고 복사하여 사용할 수 있습니다.
+    사용 가능한 모든 워크플로우 템플릿을 조회합니다.
+    템플릿은 모든 사용자가 확인하고 복사하여 사용할 수 있습니다.
 
-        ## Query Parameters
-        - page (int, optional): 페이지 번호 (1부터 시작)
-        - page_size (int, optional): 페이지당 항목 수 (1-1000)
-            - 페이지 파라미터 생략 시 전체 데이터 반환
-        - category (str, optional): 템플릿 카테고리 필터
-            - 특정 카테고리의 템플릿만 필터링
+    ## Query Parameters
+    - **page** (int, optional): 페이지 번호 (1부터 시작)
+    - **size** (int, optional): 페이지당 항목 수 (1-1000)
+        - 페이지 파라미터 생략 시 전체 데이터 반환
+        - MLOps 원본의 `page_size`에 대응 — 게이트웨이-프론트 계약에 따라 `size`로 노출
+    - **category** (str, optional): 템플릿 카테고리 필터
+        - 특정 카테고리의 템플릿만 필터링
 
-        ## Notes
-        - 모든 사용자의 템플릿이 표시됨 (creator_id 필터 없음)
-        - usage_count는 동적으로 계산됨
-        - 페이지네이션 생략 시 최대 10000개까지 반환
-        """
+    ## Response (WorkflowTemplateListSchema)
+    - **total** (int): 필터 조건에 맞는 전체 템플릿 수
+    - **items** (List[WorkflowTemplateBriefSchema]): 템플릿 목록
+        - id (str): 템플릿 UUID
+        - name (str): 템플릿 이름
+        - description (str): 템플릿 설명
+        - category (str): 템플릿 카테고리
+        - status (str): 템플릿 상태 (DRAFT)
+        - service_id (str): 기본 서비스 ID
+        - creator_id (int): 템플릿 생성자 ID
+        - creator (UserSchema): 생성자 정보
+            - id (int): 사용자 ID
+            - username (str): 사용자명
+            - name (str): 사용자 이름
+            - password (str): 비밀번호 (해시된 값)
+            - created_at (datetime): 계정 생성 시각
+            - updated_at (datetime): 계정 정보 수정 시각
+            - created_by (str, optional): 계정 생성자
+            - updated_by (str, optional): 계정 정보 수정자
+        - is_template (bool): 템플릿 여부 (항상 true)
+        - template_id (str): 원본 템플릿 ID (null)
+        - usage_count (int): 해당 템플릿으로 생성된 워크플로우 수
+        - created_at (datetime): 생성 시각
+        - updated_at (datetime): 수정 시각
+
+    (게이트웨이는 MLOps 응답을 그대로 전달합니다)
+
+    ## Notes
+    - 모든 사용자의 템플릿이 표시됨 (creator_id 필터 없음)
+    - usage_count는 동적으로 계산됨
+    - 페이지네이션 생략 시 최대 10000개까지 반환
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -350,20 +554,98 @@ async def get_template(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 템플릿 상세 조회
+    워크플로우 템플릿 상세 조회
 
-        특정 템플릿의 상세 정보를 조회합니다. 템플릿의 전체 구조와 컴포넌트, 연결 정보를 포함합니다. 템플릿은 다른 사용자들이 복사하여 사용할 수 있는 재사용 가능한 워크플로우 구조입니다.
+    특정 템플릿의 상세 정보를 조회합니다.
+    템플릿의 전체 구조와 컴포넌트, 연결 정보를 포함합니다.
+    템플릿은 다른 사용자들이 복사하여 사용할 수 있는 재사용 가능한 워크플로우 구조입니다.
 
-        ## Path Parameters
-        - template_id (str): 조회할 템플릿 UUID
-            - 템플릿 목록 조회 API(/workflows/templates)에서 확인 가능
+    ## Path Parameters
+    - **template_id** (str): 조회할 템플릿 UUID
+        - 템플릿 목록 조회 API(`/workflows/templates`)에서 확인 가능
 
-        ## Notes
-        - 템플릿은 실행할 수 없고 복사용으로만 사용 가능
-        - 모든 사용자가 템플릿을 조회할 수 있음 (공개)
-        - usage_count는 템플릿 복사 시 자동 증가
-        - 템플릿으로부터 워크플로우 생성 시 /workflows/templates/{template_id}/clone API 사용
-        """
+    ## Response (WorkflowTemplateReadSchema)
+    - **id** (str): 템플릿 UUID
+    - **name** (str): 템플릿 이름
+    - **description** (str): 템플릿 설명
+        - 템플릿의 용도와 사용 방법에 대한 설명
+    - **category** (str): 템플릿 카테고리
+        - 템플릿 분류를 위한 카테고리 (예: "Object Detection", "Classification")
+    - **status** (str): 템플릿 상태
+        - "DRAFT": 템플릿은 항상 DRAFT 상태 (실행 불가)
+    - **service_id** (str): 기본 서비스 ID
+        - 템플릿으로부터 워크플로우 생성 시 기본으로 연결될 서비스 ID
+        - null 가능 (서비스 연결 없이 생성 가능)
+    - **creator_id** (int): 템플릿 생성자 ID
+    - **creator** (UserSchema): 생성자 정보
+        - id (int): 사용자 ID
+        - username (str): 사용자명
+        - name (str): 사용자 이름
+        - password (str): 비밀번호 (해시된 값)
+        - created_at (datetime): 계정 생성 시각
+        - updated_at (datetime): 계정 정보 수정 시각
+        - created_by (str, optional): 계정 생성자
+        - updated_by (str, optional): 계정 정보 수정자
+    - **is_template** (bool): 템플릿 여부 (항상 true)
+    - **components** (List[ComponentReadSchema]): 컴포넌트 상세 정보
+        - id (str): 컴포넌트 UUID (workflow_component 테이블의 PK)
+        - workflow_id (str): 소속 워크플로우 ID (템플릿 ID)
+        - component_id (str): 컴포넌트 식별자
+            - 워크플로우 내에서 고유한 식별자 (예: "START", "END", "MODEL-1")
+        - name (str): 컴포넌트 이름
+        - type (ComponentType): 컴포넌트 타입
+            - "START": 워크플로우 시작점
+            - "END": 워크플로우 종료점
+            - "MODEL": ML 모델 실행 노드
+            - "KNOWLEDGE_BASE": 지식 베이스 검색 노드
+        - model_id (int, optional): 연결된 모델 ID
+        - knowledge_base_id (int, optional): 연결된 Knowledge Base ID
+        - prompt_id (int, optional): 연결된 프롬프트 ID
+        - model (ModelBriefReadSchema, optional): 모델 상세 정보 (MODEL 타입인 경우)
+            - id (int): 모델 ID
+            - name (str): 모델 이름
+            - description (str): 모델 설명
+            - provider_info (ModelProviderReadSchema): 모델 제공자 정보
+            - type_info (ModelTypeReadSchema): 모델 타입 정보
+            - format_info (ModelFormatReadSchema): 모델 포맷 정보
+            - parent_model_id (int, optional): 부모 모델 ID (파인튜닝인 경우 원본 모델)
+            - registry (ModelRegistryReadSchema): 모델 레지스트리 정보
+                - id (int): 레지스트리 ID
+                - artifact_path (str): 아티팩트 경로
+                - uri (str): 모델 URI
+                - run_id (str, optional): MLflow 실행 ID
+                - reference_model_id (int): 참조 모델 ID
+                - created_at / updated_at (datetime)
+            - created_at / updated_at (datetime)
+        - created_at / updated_at (datetime)
+    - **component_connections** (List[ConnectionReadSchema]): 연결 정보
+        - id (str): 연결 UUID (workflow_component_connection 테이블의 PK)
+        - workflow_id (str): 소속 워크플로우 ID (템플릿 ID)
+        - source_component_id (str): 소스 컴포넌트 ID
+        - target_component_id (str): 타겟 컴포넌트 ID
+        - source_component (ComponentReadSchema): 소스 컴포넌트 상세 정보
+        - target_component (ComponentReadSchema): 타겟 컴포넌트 상세 정보
+        - created_at (datetime): 연결 생성 시각
+    - **usage_count** (int): 해당 템플릿으로 생성된 워크플로우 수
+        - 템플릿을 복사하여 생성된 워크플로우의 총 개수
+        - 동적으로 계산됨 (실시간 반영)
+    - **created_at** (datetime): 템플릿 생성 시각
+    - **updated_at** (datetime): 템플릿 수정 시각
+
+    (게이트웨이는 MLOps 응답을 그대로 전달합니다)
+
+    ## Notes
+    - 템플릿은 실행할 수 없고 복사용으로만 사용 가능
+    - 모든 사용자가 템플릿을 조회할 수 있음 (공개)
+    - usage_count는 템플릿 복사 시 자동 증가
+    - 템플릿으로부터 워크플로우 생성 시 `/workflows/templates/{template_id}/clone` API 사용
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 템플릿을 찾을 수 없음
+        - template_id가 존재하지 않거나 삭제된 경우
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -387,39 +669,68 @@ async def update_template(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 템플릿 수정
+    워크플로우 템플릿 수정
 
-        기존 워크플로우 템플릿의 정보를 수정합니다. workflow_definition이 제공되면 컴포넌트와 연결도 함께 업데이트됩니다. 템플릿은 서비스에 연결되지 않으므로 service_id는 수정할 수 없습니다.
+    기존 워크플로우 템플릿의 정보를 수정합니다.
+    workflow_definition이 제공되면 컴포넌트와 연결도 함께 업데이트됩니다.
+    템플릿은 서비스에 연결되지 않으므로 service_id는 수정할 수 없습니다.
 
-        ## Path Parameters
-        - template_id (str): 수정할 템플릿 UUID
-            - 템플릿 목록 조회 API(/workflows/templates)에서 확인 가능
+    ## Path Parameters
+    - **template_id** (str): 수정할 템플릿 UUID
+        - 템플릿 목록 조회 API(`/workflows/templates`)에서 확인 가능
 
-        ## Request Body (WorkflowTemplateUpdateRequest)
-        - name (str, optional): 새 템플릿 이름
-        - description (str, optional): 새 설명
-        - category (str, optional): 새 카테고리
-        - status (str, optional): 새 상태 (DRAFT/ACTIVE/ERROR)
-            - 템플릿은 일반적으로 DRAFT 상태 유지 (실행 불가)
-        - workflow_definition (WorkflowUpdateDefinition, optional): 새 템플릿 구조
-            - components (List[ComponentUpdateRequest]): 컴포넌트 목록
-                - name (str): 컴포넌트 이름
-                - type (ComponentType): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
-                - model_id (int, optional): MODEL 타입인 경우 모델 ID
-                - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
-                - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID
-            - connections (List[ConnectionUpdateRequest]): 연결 목록
-                - source_component_type (ComponentType): 소스 컴포넌트 타입
-                - target_component_type (ComponentType): 타겟 컴포넌트 타입
+    ## Request Body (WorkflowTemplateUpdateRequest)
+    - **name** (str, optional): 새 템플릿 이름
+    - **description** (str, optional): 새 설명
+    - **category** (str, optional): 새 카테고리
+    - **status** (str, optional): 새 상태 (DRAFT/ACTIVE/ERROR)
+        - 템플릿은 일반적으로 DRAFT 상태 유지 (실행 불가)
+    - **workflow_definition** (WorkflowUpdateDefinition, optional): 새 템플릿 구조
+        - components (List[ComponentUpdateRequest]): 컴포넌트 목록
+            - name (str): 컴포넌트 이름
+            - type (ComponentType): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
+            - model_id (int, optional): MODEL 타입인 경우 모델 ID
+            - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
+            - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID
+        - connections (List[ConnectionUpdateRequest]): 연결 목록
+            - source_component_type (ComponentType): 소스 컴포넌트 타입
+            - target_component_type (ComponentType): 타겟 컴포넌트 타입
 
-        ## Notes
-        - 제공된 필드만 업데이트됨 (부분 업데이트 가능)
-        - workflow_definition 제공 시 기존 컴포넌트/연결은 삭제 후 재생성됨
-        - service_id는 템플릿에 포함되지 않음 (요청에서 제외, 항상 null로 유지)
-        - 템플릿은 실행할 수 없고 복사용으로만 사용 가능
-        - usage_count는 동적으로 계산됨 (파생된 워크플로우 수)
-        - 일반 워크플로우 수정은 /workflows/{workflow_id} API 사용
-        """
+    ## Response (WorkflowTemplateReadSchema)
+    - **id** (str): 템플릿 UUID
+    - **name** (str): 템플릿 이름
+    - **description** (str): 템플릿 설명
+    - **category** (str): 템플릿 카테고리
+    - **status** (str): 템플릿 상태 (DRAFT)
+    - **service_id** (str): 기본 서비스 ID (항상 null)
+    - **creator_id** (int): 템플릿 생성자 ID
+    - **creator** (UserSchema): 생성자 정보
+    - **is_template** (bool): 템플릿 여부 (항상 true)
+    - **template_id** (str): 원본 템플릿 ID (항상 null)
+    - **components** (List[ComponentReadSchema]): 컴포넌트 상세 정보
+    - **component_connections** (List[ConnectionReadSchema]): 연결 정보
+    - **usage_count** (int): 해당 템플릿으로 생성된 워크플로우 수
+        - 템플릿을 복사하여 생성된 워크플로우의 총 개수
+        - 동적으로 계산됨 (실시간 반영)
+    - **created_at** (datetime): 템플릿 생성 시각
+    - **updated_at** (datetime): 템플릿 수정 시각
+
+    (게이트웨이는 MLOps 응답을 그대로 전달합니다)
+
+    ## Notes
+    - 제공된 필드만 업데이트됨 (부분 업데이트 가능)
+    - workflow_definition 제공 시 기존 컴포넌트/연결은 삭제 후 재생성됨
+    - service_id는 템플릿에 포함되지 않음 (요청에서 제외, 항상 null로 유지)
+    - 템플릿은 실행할 수 없고 복사용으로만 사용 가능
+    - usage_count는 동적으로 계산됨 (파생된 워크플로우 수)
+    - 일반 워크플로우 수정은 `/workflows/{workflow_id}` API 사용
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 템플릿을 찾을 수 없음
+        - template_id가 존재하지 않거나 템플릿이 아닌 경우
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -449,10 +760,28 @@ async def delete_template(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 템플릿 삭제
+    워크플로우 템플릿 삭제
 
-        템플릿은 배포된 KServe InferenceService가 없으므로 즉시 DB에서 삭제됩니다. 파생된 워크플로우가 있으면 삭제 불가
-        """
+    템플릿은 배포된 KServe InferenceService가 없으므로 즉시 DB에서 삭제됩니다.
+    파생된 워크플로우가 있으면 삭제 불가.
+
+    ## Path Parameters
+    - **template_id** (str): 삭제할 템플릿 UUID
+
+    ## Response
+    - **204 No Content**: 삭제 성공 (응답 바디 없음)
+
+    ## Notes
+    - 템플릿은 배포된 리소스가 없어 즉시 삭제됨
+    - 해당 템플릿으로부터 복제된 워크플로우(파생된 워크플로우)가 존재하면 삭제 불가
+    - 삭제는 되돌릴 수 없는 작업
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 템플릿을 찾을 수 없음
+    - **409**: 파생된 워크플로우가 있어 삭제 불가
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -478,23 +807,55 @@ async def clone_template(
         current_user=Depends(get_current_user)
 ):
     """
-        템플릿으로부터 워크플로우 생성
+    템플릿으로부터 워크플로우 생성
 
-        기존 템플릿을 복사하여 새로운 워크플로우를 생성합니다. 템플릿의 모든 구조가 복사되며, 생성된 워크플로우는 즉시 실행 가능합니다.
+    기존 템플릿을 복사하여 새로운 워크플로우를 생성합니다.
+    템플릿의 모든 구조가 복사되며, 생성된 워크플로우는 즉시 실행 가능합니다.
 
-        ## Path Parameters
-        - template_id (str): 복사할 템플릿 UUID
+    ## Path Parameters
+    - **template_id** (str): 복사할 템플릿 UUID
 
-        ## Query Parameters
-        - workflow_name (str, required): 새로 생성할 워크플로우 이름
-        - service_id (int, optional): 연결할 서비스 ID
-            - 서비스와 연결시 모니터링 가능
+    ## Query Parameters
+    - **workflow_name** (str, required): 새로 생성할 워크플로우 이름
+    - **service_id** (int, optional): 연결할 서비스 ID
+        - 서비스와 연결시 모니터링 가능
+        - (MLOps 원본은 UUID str이나, 게이트웨이는 내부 서비스 매핑을 위해 int로 노출)
 
-        ## Notes
-        - 템플릿의 모든 컴포넌트와 연결이 복사됨
-        - 생성된 워크플로우는 템플릿과 독립적으로 동작
-        - template_id가 자동으로 기록됨
-        """
+    ## Response (WorkflowReadSchema)
+    - **id** (str): 생성된 워크플로우 UUID
+    - **name** (str): 워크플로우 이름
+    - **description** (str): 워크플로우 설명 (템플릿에서 복사)
+    - **category** (str): 카테고리 (템플릿에서 복사)
+    - **status** (str): 상태 (DRAFT로 시작)
+    - **service_id** (str): 연결된 서비스 ID
+    - **service_name** (str): 연결된 서비스 이름
+    - **creator_id** (int): 생성자 ID (현재 사용자, MLOps 기준)
+    - **creator** (UserSchema): 생성자 정보
+    - **is_template** (bool): 템플릿 여부 (false)
+    - **template_id** (str): 원본 템플릿 ID
+    - **template_name** (str): 원본 템플릿 이름
+    - **kubeflow_run_id** (str): Kubeflow 실행 ID (null)
+    - **components** (List[ComponentReadSchema]): 복사된 컴포넌트
+    - **component_connections** (List[ConnectionReadSchema]): 복사된 연결
+    - **created_at** (datetime): 생성 시각
+    - **updated_at** (datetime): 수정 시각
+
+    게이트웨이 추가 필드 (응답에 함께 포함):
+    - **db_id** (int): 게이트웨이 DB PK
+    - **db_created_at** (str): 게이트웨이 DB 생성 시각 (ISO 8601)
+    - **db_created_by** (str): 게이트웨이 사용자 member_id
+
+    ## Notes
+    - 템플릿의 모든 컴포넌트와 연결이 복사됨
+    - 생성된 워크플로우는 템플릿과 독립적으로 동작
+    - template_id가 자동으로 기록됨
+    - MLOps에는 복제되었으나 게이트웨이 DB 저장에 실패하는 경우 경고만 기록하고 MLOps 응답은 그대로 반환
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 템플릿을 찾을 수 없음
+    - **500**: 서버 내부 오류
+    """
     user_info = {
         'member_id': current_user.member_id,
         'role': current_user.role,
@@ -543,21 +904,85 @@ async def get_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 상세정보 조회
+    워크플로우 상세정보 조회
 
-        특정 워크플로우의 상세 정보를 조회합니다. 컴포넌트, 연결, 배포 상태 등 모든 정보를 포함합니다. 워크플로우 실행 상태, 배포된 모델 정보, Kubeflow 파이프라인 실행 정보 등을 확인할 수 있습니다.
+    특정 워크플로우의 상세 정보를 조회합니다.
+    컴포넌트, 연결, 배포 상태 등 모든 정보를 포함합니다.
+    워크플로우 실행 상태, 배포된 모델 정보, Kubeflow 파이프라인 실행 정보 등을 확인할 수 있습니다.
 
-        ## Path Parameters
-        - workflow_id (str): 조회할 워크플로우 UUID
-            - 워크플로우 목록 조회 API(/workflows)에서 확인 가능
+    ## Path Parameters
+    - **workflow_id** (str): 조회할 워크플로우 UUID (MLOps 기준)
+        - 워크플로우 목록 조회 API(`/workflows`)에서 확인 가능
+        - 게이트웨이에서는 `surro_workflow_id`로도 참조
 
-        ## Notes
-        - public_url과 backend_api_url은 워크플로우 실행 후 배포가 완료되면 동적으로 생성됨
-        - 템플릿인 경우 is_template=true (템플릿 조회 API 사용 권장)
-        - kubeflow_run_id가 있으면 /workflows/{workflow_id}/status로 실행 상태 확인 가능
-        - 배포된 모델 정보는 /workflows/{workflow_id}/models로 확인 가능
-        - 워크플로우 실행은 /workflows/{workflow_id}/execute API 사용
-        """
+    ## Response (WorkflowDetailResponse)
+    - **id** (int): 게이트웨이 DB PK
+    - **surro_workflow_id** (str): MLOps 워크플로우 UUID
+    - **created_at** (datetime): 게이트웨이 DB 기준 생성 시각
+    - **updated_at** (datetime): 게이트웨이 DB 기준 수정 시각
+    - **created_by** (str): 게이트웨이 사용자 member_id
+    - **name** (str): 워크플로우 이름
+    - **description** (str): 워크플로우 설명
+        - 워크플로우의 용도와 목적에 대한 설명
+    - **category** (str): 워크플로우 카테고리
+        - 워크플로우 분류를 위한 카테고리 (예: "Object Detection", "Classification")
+    - **status** (str): 워크플로우 상태
+        - "DRAFT": 임시저장 상태 (아직 실행되지 않음)
+        - "ACTIVE": 활성 상태 (배포 완료, 실행 가능)
+        - "ERROR": 오류 발생 상태 (실행 실패 또는 배포 오류)
+    - **service_id** (str): 연결된 서비스 ID
+        - 모니터링 및 서비스 관리용 서비스 ID
+        - null 가능 (서비스 연결 없이도 워크플로우 생성 가능)
+    - **service_name** (str): 연결된 서비스 이름
+        - service_id로부터 동적으로 조회된 서비스 이름
+        - service_id가 null이면 null
+    - **creator_id** (int): MLOps 기준 생성자 ID
+    - **is_template** (bool): 템플릿 여부
+        - false: 일반 워크플로우
+        - true: 템플릿 (템플릿 조회 API 사용 권장)
+    - **template_id** (str): 원본 템플릿 ID
+        - 템플릿으로부터 생성된 경우 원본 템플릿 ID
+        - 직접 생성한 경우 null
+    - **template_name** (str): 원본 템플릿 이름
+    - **kubeflow_run_id** (str): Kubeflow 파이프라인 실행 ID
+        - 워크플로우 실행 시 생성된 Kubeflow Pipeline 실행 ID
+        - 실행 전이면 null
+    - **public_url** (str): KServe 공개 엔드포인트 URL
+        - 배포 후 동적으로 생성되는 공개 접근 URL
+        - 배포 전이면 null
+        - 형식: `{gateway_url}/v2/models/{model_name}/infer`
+    - **backend_api_url** (str): 백엔드 API URL
+        - 배포 후 동적으로 생성되는 백엔드 API URL
+        - 배포 전이면 null
+    - **components** (List[ComponentReadSchema]): 컴포넌트 목록
+        - id / workflow_id / component_id / name / type (START|END|MODEL|KNOWLEDGE_BASE)
+        - model_id / knowledge_base_id / prompt_id (optional)
+        - model (ModelBriefReadSchema, optional): MODEL 타입인 경우 상세 정보
+            - id / name / description
+            - provider_info / type_info / format_info
+            - parent_model_id / registry / created_at / updated_at
+        - created_at / updated_at
+    - **component_connections** (List[ConnectionReadSchema]): 연결 정보
+        - id / workflow_id / source_component_id / target_component_id
+        - source_component / target_component (ComponentReadSchema 전체)
+        - created_at
+
+    (MLOps 원본의 `creator`(UserSchema)는 MLOps 슈퍼어드민 정보라 게이트웨이에서는
+     별도로 반환하지 않고, 대신 `created_by`(member_id)를 제공)
+
+    ## Notes
+    - public_url과 backend_api_url은 워크플로우 실행 후 배포가 완료되면 동적으로 생성됨
+    - 템플릿인 경우 is_template=true (템플릿 조회 API 사용 권장)
+    - kubeflow_run_id가 있으면 `/workflows/{workflow_id}/status`로 실행 상태 확인 가능
+    - 배포된 모델 정보는 `/workflows/{workflow_id}/models`로 확인 가능
+    - 워크플로우 실행은 `/workflows/{workflow_id}/execute` API 사용
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+        - 게이트웨이 DB 또는 MLOps 어느 한 쪽에서 찾지 못한 경우
+    - **500**: 서버 내부 오류
+    """
     # DB에서 조회
     db_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -615,50 +1040,71 @@ async def update_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 수정
+    워크플로우 수정
 
-        기존 워크플로우의 정보를 수정합니다. workflow_definition이 제공되면 컴포넌트와 연결도 함께 업데이트됩니다.
+    기존 워크플로우의 정보를 수정합니다.
+    workflow_definition이 제공되면 컴포넌트와 연결도 함께 업데이트됩니다.
 
-        ## Path Parameters
-        - workflow_id (str): 수정할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 수정할 워크플로우 UUID
 
-        ## Request Body (WorkflowUpdateRequest)
-        - name (str, optional): 새 워크플로우 이름
-        - description (str, optional): 새 설명
-        - category (str, optional): 새 카테고리
-        - status (str, optional): 새 상태 (DRAFT/ACTIVE/ERROR)
-            - "DRAFT": 임시저장 상태 (아직 실행되지 않음)
-            - "ACTIVE": 활성 상태 (배포 완료, 실행 가능)
-            - "ERROR": 오류 발생 상태 (실행 실패 또는 배포 오류)
-        - service_id (str, optional): 연결할 서비스 ID
-            - 모니터링 및 서비스 관리용 서비스 ID
-            - null로 설정 시 서비스 연결 해제
-        - workflow_definition (WorkflowUpdateDefinition, optional): 새 워크플로우 구조
-            - components (List[ComponentUpdateRequest]): 컴포넌트 목록
-                - name (str): 컴포넌트 이름
-                - type (ComponentType): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
-                    - "START": 워크플로우 시작점
-                    - "END": 워크플로우 종료점
-                    - "MODEL": ML 모델 실행 노드
-                    - "KNOWLEDGE_BASE": 지식 베이스 검색 노드
-                - model_id (int, optional): MODEL 타입인 경우 모델 ID
-                    - MODEL 타입인 경우 필수, 다른 타입은 null
-                - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
-                    - KNOWLEDGE_BASE 타입인 경우 필수, 다른 타입은 null
-                - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID
-                    - MODEL 타입인 경우 선택, 다른 타입은 null
-            - connections (List[ConnectionUpdateRequest]): 연결 목록
-                - source_component_type (ComponentType): 소스 컴포넌트 타입
-                - target_component_type (ComponentType): 타겟 컴포넌트 타입
+    ## Request Body (WorkflowUpdateRequest)
+    - **name** (str, optional): 새 워크플로우 이름
+    - **description** (str, optional): 새 설명
+    - **category** (str, optional): 새 카테고리
+    - **status** (str, optional): 새 상태 (DRAFT/ACTIVE/ERROR)
+        - "DRAFT": 임시저장 상태 (아직 실행되지 않음)
+        - "ACTIVE": 활성 상태 (배포 완료, 실행 가능)
+        - "ERROR": 오류 발생 상태 (실행 실패 또는 배포 오류)
+    - **service_id** (str, optional): 연결할 서비스 ID
+        - 모니터링 및 서비스 관리용 서비스 ID
+        - null로 설정 시 서비스 연결 해제
+    - **workflow_definition** (WorkflowUpdateDefinition, optional): 새 워크플로우 구조
+        - components (List[ComponentUpdateRequest]): 컴포넌트 목록
+            - name (str): 컴포넌트 이름
+            - type (ComponentType): 타입 (START/END/MODEL/KNOWLEDGE_BASE)
+                - "START": 워크플로우 시작점
+                - "END": 워크플로우 종료점
+                - "MODEL": ML 모델 실행 노드
+                - "KNOWLEDGE_BASE": 지식 베이스 검색 노드
+            - model_id (int, optional): MODEL 타입인 경우 모델 ID
+            - knowledge_base_id (int, optional): KNOWLEDGE_BASE 타입인 경우 Knowledge Base ID
+            - prompt_id (int, optional): MODEL 타입인 경우 프롬프트 ID (선택)
+        - connections (List[ConnectionUpdateRequest]): 연결 목록
+            - source_component_type (ComponentType): 소스 컴포넌트 타입
+            - target_component_type (ComponentType): 타겟 컴포넌트 타입
 
-        ## Notes
-        - 제공된 필드만 업데이트됨 (부분 업데이트 가능)
-        - workflow_definition 제공 시 기존 컴포넌트/연결은 삭제 후 재생성됨
-        - status를 ACTIVE로 변경해도 자동 배포되지 않음 (execute API 사용 필요)
-        - service_id를 null로 설정하면 서비스 연결이 해제됨
-        - 템플릿 수정은 /workflows/templates/{template_id} API 사용
-        - 배포된 워크플로우의 구조 변경 시 재배포 필요
-        """
+    ## Response (WorkflowResponse)
+    - **id** (int): 게이트웨이 DB PK
+    - **surro_workflow_id** (str): MLOps 워크플로우 UUID
+    - **created_at** / **updated_at** (datetime): 게이트웨이 DB 메타
+    - **created_by** (str): 게이트웨이 사용자 member_id
+    - **name** (str): 워크플로우 이름
+    - **description** (str): 워크플로우 설명
+    - **category** (str): 워크플로우 카테고리
+    - **status** (str): 워크플로우 상태 (DRAFT/ACTIVE/ERROR)
+    - **service_id** (str): 연결된 서비스 ID
+    - **is_template** (bool): 템플릿 여부 (false)
+    - **template_id** (str): 원본 템플릿 ID
+
+    (MLOps 원본 응답의 `creator` / `components` / `component_connections` / `kubeflow_run_id` /
+     `public_url` / `backend_api_url` 등 상세 정보는 `GET /workflows/{workflow_id}`로 별도 조회)
+
+    ## Notes
+    - 제공된 필드만 업데이트됨 (부분 업데이트 가능)
+    - workflow_definition 제공 시 기존 컴포넌트/연결은 삭제 후 재생성됨
+    - status를 ACTIVE로 변경해도 자동 배포되지 않음 (execute API 사용 필요)
+    - service_id를 null로 설정하면 서비스 연결이 해제됨
+    - 템플릿 수정은 `/workflows/templates/{template_id}` API 사용
+    - 배포된 워크플로우의 구조 변경 시 재배포 필요
+    - 게이트웨이 권한 검사: admin 이거나 해당 워크플로우의 `created_by` 사용자만 수정 가능
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **403**: 권한 없음 (본인 소유가 아니며 admin도 아님)
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 서버 내부 오류
+    """
     # 우리 DB에서 기존 워크플로우 조회 (권한 확인용)
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -744,23 +1190,40 @@ async def delete_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 삭제 시작 (2단계 프로세스)
+    워크플로우 삭제 시작 (2단계 프로세스)
 
-        워크플로우 삭제를 시작합니다. KServe InferenceService를 정리하는 Kubeflow Pipeline을 실행하고 cleanup_run_id를 반환합니다. 실제 DB 삭제는 finalize-deletion API를 통해 완료 확인 후 수행됩니다.
+    워크플로우 삭제를 시작합니다. KServe InferenceService를 정리하는
+    Kubeflow Pipeline을 실행하고 cleanup_run_id를 반환합니다.
+    실제 DB 삭제는 `finalize-deletion` API를 통해 완료 확인 후 수행됩니다.
 
-        ## Path Parameters
-        - workflow_id (str): 삭제할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 삭제할 워크플로우 UUID
 
-        ## Deletion Process
-        1. 현재 API 호출: 정리 파이프라인 시작
-        2. Kubeflow Pipeline: KServe InferenceService 삭제
-        3. finalize-deletion API: 완료 확인 및 DB 삭제
+    ## Response (202 Accepted)
+    - **message** (str): 상태 메시지 "Workflow deletion started"
+    - **workflow_id** (str): 워크플로우 UUID
+    - **cleanup_run_id** (str): 정리 파이프라인 실행 ID
+    - **status** (str): 현재 상태 "cleanup_in_progress"
+    - **next_step** (str): 다음 단계 API 안내
+        - 형식: "Call /workflows/{workflow_id}/finalize-deletion to complete deletion"
 
-        ## Notes
-        - 비동기 프로세스로 진행됨 (202 Accepted)
-        - KServe 리소스 정리에 시간이 걸릴 수 있음
-        - 템플릿은 바로 DB에서 삭제됨 (배포 리소스 없음)
-        """
+    ## Deletion Process
+    1. 현재 API 호출: 정리 파이프라인 시작
+    2. Kubeflow Pipeline: KServe InferenceService 삭제
+    3. `finalize-deletion` API 호출: Kubernetes 리소스 직접 확인 및 DB 삭제
+
+    ## Notes
+    - 비동기 프로세스로 진행됨 (202 Accepted)
+    - KServe 리소스 정리에 시간이 걸릴 수 있음
+    - 템플릿은 바로 DB에서 삭제됨 (배포 리소스 없음)
+    - 게이트웨이 권한 검사: admin 이거나 해당 워크플로우의 `created_by` 사용자만 삭제 가능
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **403**: 권한 없음 (본인 소유가 아니며 admin도 아님)
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 정리 파이프라인 시작 실패
+    """
     # 외부 ID로 우리 DB에서 기존 워크플로우 조회
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -800,28 +1263,57 @@ async def finalize_workflow_deletion(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 삭제 완료 처리
+    워크플로우 삭제 완료 처리
 
-        KServe 리소스 정리가 완료되었는지 확인하고, 완료된 경우 DB에서 워크플로우를 삭제합니다.
+    Kubernetes 클러스터를 직접 조회하여 리소스가 실제로 삭제되었는지 확인하고,
+    확인된 경우 DB에서 워크플로우를 삭제합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 삭제할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 삭제할 워크플로우 UUID
 
-        ## Query Parameters
-        - run_id (str, required): Kubeflow Pipeline cleanup run ID
-            - delete API에서 반환된 cleanup_run_id 사용
+    ## Query Parameters
+    - **run_id** (str, required): Kubeflow Pipeline cleanup run ID
+        - `DELETE /workflows/{workflow_id}` 응답의 `cleanup_run_id` 사용
 
-        ## Process
-        1. Pipeline 상태 확인 (5초 타임아웃)
-        2. 완료 시: DB에서 워크플로우 삭제
-        3. 진행중: 진행 상태 반환
-        4. 실패: 오류 메시지 반환
+    ## Response
+    - **workflow_id** (str): 워크플로우 UUID
+    - **status** (str): 삭제 상태
+        - "completed": 삭제 완료
+            - Kubernetes 리소스가 실제로 삭제되어 확인됨
+            - DB에서 워크플로우가 삭제됨
+        - "in_progress": 아직 진행중
+            - Kubernetes에 리소스가 아직 존재함
+            - 완료될 때까지 대기 후 재호출 필요
+        - "failed": 삭제 실패
+            - Kubernetes 리소스 확인 중 오류 발생
+            - error_message에 상세 오류 정보 포함
+    - **deleted_from_db** (bool): DB에서 삭제 여부
+        - true: 완전히 삭제됨
+        - false: 아직 삭제되지 않음
+    - **message** (str): 상태 메시지
 
-        ## Notes
-        - 이미 삭제된 워크플로우 호출 시 "already deleted" 반환
-        - Pipeline 상태 확인에 실패해도 DB 조회 시도
-        - 삭제는 되돌릴 수 없는 작업
-        """
+    게이트웨이는 `status == "completed"` 이면서 `deleted_from_db == true` 일 때
+    게이트웨이 DB의 매핑 레코드(workflows 테이블)도 함께 삭제합니다.
+
+    ## Process
+    1. 워크플로우 존재 여부 확인
+    2. Kubernetes 클러스터에서 리소스 직접 조회
+       - InferenceService 조회
+       - Ollama Deployment/Service 조회
+    3. 리소스가 모두 삭제된 경우: MLOps DB + 게이트웨이 DB에서 워크플로우 삭제
+    4. 리소스가 아직 존재하는 경우: 진행중 상태 반환 (재호출 필요)
+    5. 확인 중 오류 발생: 실패 상태 반환
+
+    ## Notes
+    - 이미 삭제된 워크플로우 호출 시 "already deleted" 반환
+    - Kubernetes 리소스 확인에 실패해도 DB 조회 시도
+    - 삭제는 되돌릴 수 없는 작업
+    - 리소스가 아직 존재하면 재호출하여 완료 확인 필요
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **500**: 삭제 처리 중 오류 발생
+    """
     # 외부 API 삭제 완료 확인
     user_info = {
         'member_id': current_user.member_id,
@@ -863,8 +1355,27 @@ async def execute_workflow(
     """
     워크플로우 실행 (KServe 배포 + Kubeflow 파이프라인 실행)
 
-    워크플로우를 실행하여 ML 모델을 배포합니다. Kubeflow 파이프라인을 통해 KServe InferenceService를 생성하고,
+    워크플로우를 실행하여 ML 모델을 배포합니다.
+    Kubeflow 파이프라인을 통해 KServe InferenceService를 생성하고,
     모델 서빙 엔드포인트를 활성화합니다.
+
+    ## Path Parameters
+    - **workflow_id** (str): 실행할 워크플로우 UUID
+
+    ## Request Body (WorkflowExecuteRequest)
+    - **parameters** (Dict[str, Any], optional): 실행 파라미터
+        - 커스텀 설정 값들을 전달할 수 있음
+        - 예: `{"gpus": 1, "replicas": 2}`
+
+    ## Response (WorkflowExecuteResponse)
+    - **workflow_id** (str): 실행된 워크플로우 UUID
+    - **kubeflow_run_id** (str): Kubeflow 파이프라인 실행 ID
+    - **status** (str): 실행 상태
+        - "PENDING": 대기중
+        - "RUNNING": 실행중
+        - "SUCCEEDED": 성공
+        - "FAILED": 실패
+    - **message** (str): 상태 메시지
 
     ## Process
     1. 지식베이스가 모델 앞에 있는지 검증
@@ -873,33 +1384,19 @@ async def execute_workflow(
     4. 파이프라인 실행 및 모니터링 시작
     5. KServeDeployment 테이블에 배포 정보 기록
 
-    ## Response Status
-    - **PENDING**: 대기중
-    - **RUNNING**: 실행중
-    - **SUCCEEDED**: 성공
-    - **FAILED**: 실패
-
     ## Notes
-    - 워크플로우 상태가 **ERROR**인 경우만 실행 불가
-    - **DRAFT** 상태에서도 실행 가능 (파이프라인 완료 시 자동으로 ACTIVE로 변경됨)
+    - 워크플로우 상태가 ERROR인 경우만 실행 불가
+    - DRAFT 상태에서도 실행 가능 (파이프라인 완료 시 자동으로 ACTIVE로 변경됨)
     - 지식베이스 컴포넌트는 모델 컴포넌트보다 앞에 있어야 함
     - 배포된 모델은 `/workflows/{workflow_id}/models`로 확인
     - 실행 상태는 `/workflows/{workflow_id}/status`로 모니터링
-    - 파이프라인 완료 시 워크플로우 상태가 자동으로 **ACTIVE**로 변경됨
-
-    ## Example Request
-    ```json
-    {
-      "parameters": {
-        "gpu_enabled": true,
-        "replicas": 2
-      }
-    }
-    ```
+    - 파이프라인 완료 시 워크플로우 상태가 자동으로 ACTIVE로 변경됨
 
     ## Errors
-    - **400**: 워크플로우 상태가 ERROR이거나 실행할 수 없는 경우
-    - **404**: 워크플로우를 찾을 수 없는 경우
+    - **400**: 워크플로우가 ERROR 상태이거나 지식베이스가 모델 뒤에 있음
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 실행 중 오류 발생
     """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
@@ -931,23 +1428,60 @@ async def get_workflow_status(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 실행 상태 조회
+    워크플로우 실행 상태 조회
 
-        워크플로우의 실행 상태와 배포된 모델들의 상태를 종합적으로 조회합니다. KServe 배포 상태와 Kubeflow 파이프라인 실행 상태를 모두 포함합니다.
+    워크플로우의 실행 상태와 배포된 모델들의 상태를 종합적으로 조회합니다.
+    KServe 배포 상태와 Kubeflow 파이프라인 실행 상태를 모두 포함합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 조회할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 조회할 워크플로우 UUID
 
-        ## Notes
-        - 워크플로우가 실행되지 않았다면 kubeflow_run_id는 null
-        - deployed_models는 MODEL 타입 컴포넌트가 있는 경우만 포함
-        - 모든 조회는 DB 기반으로 수행되며, Kubernetes나 Kubeflow를 직접 조회하지 않음
-        - 배포 상태는 kserve_deployments 테이블의 정보를 기반으로 함
-        - deployed_models 조회 실패 시에도 에러를 발생시키지 않고 빈 리스트로 처리됨
+    ## Response
+    - **workflow_id** (str): 워크플로우 UUID
+        - `str(workflow.id)`로 변환된 값
+    - **status** (str): 워크플로우 상태
+        - "DRAFT": 임시저장 상태 (아직 실행되지 않음)
+        - "ACTIVE": 활성 상태 (배포 완료, 실행 가능)
+        - "ERROR": 오류 발생 상태 (실행 실패 또는 배포 오류)
+    - **kubeflow_run_id** (str, optional): Kubeflow 파이프라인 실행 ID
+        - 워크플로우가 실행된 경우에만 포함
+        - 실행 전이면 null
+        - 참조용으로만 포함되며, 실제 파이프라인 상태는 조회하지 않음
+    - **deployed_models** (List[dict]): 배포된 모델 목록
+        - **component_id** (str): 컴포넌트 UUID
+        - **service_name** (str): KServe InferenceService 이름 (DNS 1035 규칙 준수)
+        - **service_hostname** (str): KServe 서비스 호스트명
+            - Istio Virtual Service 라우팅에 사용
+            - 형식: `{service_name}.{namespace}.example.com`
+        - **model_name** (str): 컴포넌트 이름 (사용자가 지정한 이름)
+        - **sanitized_model_name** (str): 정제된 모델 이름
+            - DNS 규칙에 맞게 변환된 모델 이름 (슬래시가 하이픈으로 변경됨)
+            - KServe 엔드포인트에서 실제로 사용되는 이름
+        - **model_id** (int, optional): 모델 ID (MODEL 타입 컴포넌트인 경우)
+        - **internal_url** (str, optional): 내부 접근 URL
+            - 형식: `http://{service_name}.{namespace}.svc.cluster.local`
+        - **gateway_url** (str): 외부에서 접근 가능한 KServe Gateway 엔드포인트 URL
+        - **status** (str): 배포 상태
+            - "DEPLOYING": 배포 중
+            - "DEPLOYED": 배포 완료
+            - "FAILED": 배포 실패
+            - "DELETED": 삭제됨
+        - **deployed_at** (str, optional): 배포 시각 (ISO 8601)
+        - **error_message** (str, optional): 배포 실패 시 오류 내용
+    - **error** (str, optional): 상태 조회 실패 시 오류 메시지
 
-        ## Errors
-        - **404**: 워크플로우를 찾을 수 없는 경우
-        """
+    ## Notes
+    - 워크플로우가 실행되지 않았다면 `kubeflow_run_id`는 null
+    - `deployed_models`는 MODEL 타입 컴포넌트가 있는 경우만 포함
+    - 모든 조회는 DB 기반으로 수행되며, Kubernetes나 Kubeflow를 직접 조회하지 않음
+    - 배포 상태는 `kserve_deployments` 테이블의 정보를 기반으로 함
+    - `deployed_models` 조회 실패 시에도 에러를 발생시키지 않고 빈 리스트로 처리됨
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 상태 조회 중 오류 발생 (응답에 `error` 필드가 포함될 수 있음)
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -987,9 +1521,41 @@ async def update_component_deployment_status(
     """
     컴포넌트의 KServe 배포 상태를 업데이트합니다.
 
-    중요: 이 API는 Kubeflow Pipeline 내부에서만 호출되는 내부 API입니다. 프론트엔드나 외부 클라이언트에서는 사용하지 않아야 합니다.
+    **중요**: 이 API는 Kubeflow Pipeline 내부에서만 호출되는 내부 API입니다.
+    프론트엔드나 외부 클라이언트에서는 사용하지 않아야 합니다.
 
-    Kubeflow Pipeline 실행 중 컴포넌트의 KServe 배포가 완료되면, Pipeline 내부에서 자동으로 이 API를 호출하여 배포 상태를 업데이트합니다.
+    Kubeflow Pipeline 실행 중 컴포넌트의 KServe 배포가 완료되면,
+    Pipeline 내부에서 자동으로 이 API를 호출하여 배포 상태를 업데이트합니다.
+
+    ## Path Parameters
+    - **workflow_id** (str): 워크플로우 ID
+    - **component_id** (str): 컴포넌트 UUID
+
+    ## Request Body (Form Data)
+    - **service_name** (str, required): KServe 서비스 이름
+    - **service_hostname** (str, required): KServe 서비스 호스트명
+    - **model_name** (str, required): 배포된 모델 이름
+    - **status** (str, required): 배포 상태 (예: "ready", "failed")
+    - **internal_url** (str, optional): 내부 서비스 URL
+    - **error_message** (str, optional): 배포 실패 시 에러 메시지
+
+    ## Response
+    - **message** (str): 업데이트 결과 메시지
+    - **deployment_info** (dict): 배포 정보
+        - service_name (str): 서비스 이름
+        - service_hostname (str): 서비스 호스트명
+        - model_name (str): 모델 이름
+        - status (str): 배포 상태
+        - internal_url (str, optional): 내부 서비스 URL
+
+    ## Notes
+    - 이 API는 Kubeflow Pipeline의 컴포넌트 내부에서만 호출됩니다
+    - 프론트엔드나 사용자 애플리케이션에서는 직접 호출하지 않아야 합니다
+    - 배포 상태는 Pipeline 실행 중 자동으로 업데이트됩니다
+
+    ## Errors
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 배포 상태 업데이트 중 서버 내부 오류
     """
     user_info = {
         'member_id': current_user.member_id,
@@ -1021,33 +1587,76 @@ async def test_rag_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        RAG 워크플로우 테스트
+    RAG 워크플로우 테스트
 
-        Knowledge Base와 LLM 모델을 사용하는 RAG 워크플로우를 테스트합니다. 지식베이스가 있으면 검색 후 결과를 LLM 모델에 전달하여 추론하고, 지식베이스가 없으면 LLM 모델만 실행합니다.
+    Knowledge Base와 LLM 모델을 사용하는 RAG 워크플로우를 테스트합니다.
+    지식베이스가 있으면 검색 후 결과를 LLM 모델에 전달하여 추론하고,
+    지식베이스가 없으면 LLM 모델만 실행합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 테스트할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 테스트할 워크플로우 UUID
 
-        ## Request Body (Form Data)
-        - text (str, required): 검색 쿼리 및 LLM 입력 텍스트
+    ## Request Body (Form Data)
+    - **text** (str, required): 검색 쿼리 및 LLM 입력 텍스트
 
-        ## Notes
-        - 워크플로우는 배포되어 있어야 함 (ACTIVE 상태)
-        - 워크플로우에 최소 하나의 LLM MODEL 컴포넌트 또는 KNOWLEDGE_BASE 컴포넌트가 있어야 함
-        - Knowledge Base 컴포넌트는 선택 사항 (있으면 검색 후 결과를 LLM에 전달)
-        - 지식베이스 검색 결과는 자동으로 LLM 모델의 context 파라미터로 전달됨
-        - prompt_id가 설정된 경우:
-            - prompt에 context 변수가 있으면: prompt의 {context} 또는 {{context}} 위치에 자동 치환
-            - prompt에 context 변수가 없어도: [참고자료] 태그와 함께 별도의 system 메시지로 추가
-            - prompt_id가 없는 경우: [참고자료] 태그와 함께 system 메시지로 추가
-        - 각 컴포넌트의 실행 결과는 results 배열에 순서대로 포함됨
-        - final_result는 최종 결과 문자열만 포함 (LLM 응답 또는 검색 결과)
-        - 상세 정보 (total, search_method, full_response 등)는 results 배열의 각 컴포넌트 결과에서 확인 가능
+    ## Response (WorkflowTestResponse)
+    - **workflow_id** (str): 워크플로우 UUID
+    - **execution_order** (List[str]): 실행된 컴포넌트 ID 순서 (워크플로우 실행 순서)
+    - **results** (List[ComponentTestResult]): 각 컴포넌트 실행 결과 목록
+        - 각 항목은 다음 중 하나의 타입:
 
-        ## Errors
-        - **400**: 워크플로우가 배포되지 않았거나 테스트할 수 없는 구성인 경우
-        - **404**: 워크플로우를 찾을 수 없는 경우
-        """
+        **KnowledgeBaseComponentTestResult** (지식베이스 컴포넌트인 경우):
+        - **component_id** (str): 컴포넌트 UUID
+        - **component_name** (str): 컴포넌트 이름
+        - **component_type** (str): "KNOWLEDGE_BASE"
+        - **model_type** (str): "embedding"
+        - **result** (KnowledgeBaseTestResult): 검색 결과
+            - **search_result** (str): 검색 결과 문자열 (LLM 프롬프트에 사용 가능한 형식)
+            - **total** (int): 검색 결과 총 개수
+            - **search_method** (str): 검색 방법 (예: "similarity", "keyword")
+
+        **ModelComponentTestResult** (LLM 모델 컴포넌트인 경우):
+        - **component_id** (str): 컴포넌트 UUID
+        - **component_name** (str): 컴포넌트 이름
+        - **component_type** (str): "MODEL"
+        - **model_type** (str): "LLM"
+        - **result** (ModelLLMTestResult): LLM 추론 결과
+            - **response** (str): LLM 응답 텍스트
+            - **full_response** (dict, optional): Ollama API 전체 응답 (디버깅용)
+
+        **ComponentTestErrorResult** (오류 발생 시):
+        - **component_id** (str): 컴포넌트 UUID
+        - **component_name** (str): 컴포넌트 이름
+        - **component_type** (str): "KNOWLEDGE_BASE" 또는 "MODEL"
+        - **model_type** (str, optional): 모델 타입 (오류 발생 시 null 가능)
+        - **error** (str): 오류 메시지
+
+    - **final_result** (str, optional): 최종 결과 문자열
+        - 우선순위: 마지막 LLM MODEL 컴포넌트의 응답 > 마지막 KNOWLEDGE_BASE 컴포넌트의 검색 결과
+        - MODEL 컴포넌트가 있으면: LLM 응답 텍스트 (response)
+        - MODEL 컴포넌트가 없고 KNOWLEDGE_BASE만 있으면: 검색 결과 문자열 (search_result)
+        - 상세 정보는 results 배열의 각 컴포넌트 결과에서 확인 가능
+
+    ## Notes
+    - 워크플로우는 배포되어 있어야 함 (ACTIVE 상태)
+    - 워크플로우에 최소 하나의 LLM MODEL 컴포넌트 또는 KNOWLEDGE_BASE 컴포넌트가 있어야 함
+    - Knowledge Base 컴포넌트는 선택 사항 (있으면 검색 후 결과를 LLM에 전달)
+    - 지식베이스 검색 결과는 자동으로 LLM 모델의 context 파라미터로 전달됨
+    - prompt_id가 설정된 경우:
+        - prompt에 context 변수가 있으면: prompt의 {context} 또는 {{context}} 위치에 자동 치환
+        - prompt에 context 변수가 없어도: [참고자료] 태그와 함께 별도의 system 메시지로 추가
+    - prompt_id가 없는 경우: [참고자료] 태그와 함께 system 메시지로 추가
+    - 각 컴포넌트의 실행 결과는 results 배열에 순서대로 포함됨
+    - final_result는 최종 결과 문자열만 포함 (LLM 응답 또는 검색 결과)
+    - 상세 정보 (total, search_method, full_response 등)는 results 배열의 각 컴포넌트 결과에서 확인 가능
+
+    ## Errors
+    - **400**: 잘못된 요청 (RAG 워크플로우가 아님, 필수 파라미터 누락 등)
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+    - **503**: 모델 서비스가 준비되지 않음
+    - **500**: 서버 내부 오류
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -1080,32 +1689,69 @@ async def test_ml_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        ML 워크플로우 테스트
+    ML 워크플로우 테스트
 
-        Object Detection Model을 사용하는 ML 워크플로우를 테스트합니다.
+    Object Detection Model을 사용하는 ML 워크플로우를 테스트합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 테스트할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 테스트할 워크플로우 UUID
 
-        ## Request Body (Form Data)
-        - image (file, required): 이미지 파일 (ODM 추론용)
-            - 지원 형식: JPEG, PNG, GIF, WebP
-            - Base64로 인코딩되어 서버로 전송
+    ## Request Body (Form Data)
+    - **image** (file, required): 이미지 파일 (ODM 추론용)
+        - 지원 형식: JPEG, PNG, GIF, WebP
+        - Base64로 인코딩되어 서버로 전송
 
-        ## Notes
-        - 워크플로우는 배포되어 있어야 함 (ACTIVE 상태)
-        - 워크플로우에 최소 하나의 ODM MODEL 컴포넌트가 있어야 함
-        - KNOWLEDGE_BASE 컴포넌트는 포함될 수 없음 (ML 워크플로우는 ODM만 지원)
-        - 각 컴포넌트의 실행 결과는 results 배열에 순서대로 포함됨
-        - final_result는 입력 이미지에 bbox와 label이 그려진 이미지를 base64로 인코딩한 문자열
-        - bbox는 빨간색으로, label은 빨간 배경에 흰색 텍스트로 표시됨
+    ## Response (WorkflowTestResponse)
+    - **workflow_id** (str): 워크플로우 UUID
+    - **execution_order** (List[str]): 실행된 컴포넌트 ID 순서 (워크플로우 실행 순서)
+    - **results** (List[ComponentTestResult]): 각 컴포넌트 실행 결과 목록
+        - 각 항목은 다음 중 하나의 타입:
+
+        **ModelComponentTestResult** (ODM 모델 컴포넌트인 경우):
+        - **component_id** (str): 컴포넌트 UUID
+        - **component_name** (str): 컴포넌트 이름
+        - **component_type** (str): "MODEL"
+        - **model_type** (str): "ODM"
+        - **result** (ModelODMTestResult): ODM 추론 결과
+            - **predictions** (List[dict]): 추론 결과 목록
+                - 각 항목은 다음 필드를 포함:
+                    - **score** (float): 객체 감지 신뢰도 점수 (0.0 ~ 1.0)
+                    - **label** (str): 감지된 객체의 레이블 (예: "person", "laptop")
+                    - **box** (List[float]): 바운딩 박스 좌표 [x1, y1, x2, y2]
+            - **image_info** (dict, optional): 이미지 메타데이터
+                - **original_size** (dict): 원본 이미지 크기
+                - **model_input_size** (dict): 모델 입력 크기
+
+        **ComponentTestErrorResult** (오류 발생 시):
+        - **component_id** (str): 컴포넌트 UUID
+        - **component_name** (str): 컴포넌트 이름
+        - **component_type** (str): "MODEL"
+        - **model_type** (str, optional): "ODM" (오류 발생 시 null 가능)
+        - **error** (str): 오류 메시지
+
+    - **final_result** (str, optional): 최종 결과 이미지 (base64 인코딩)
+        - 입력 이미지에 마지막 ODM MODEL 컴포넌트의 predictions를 이용해 bbox와 label을 그린 이미지
+        - base64로 인코딩된 JPEG 이미지 문자열
+        - predictions가 없거나 에러 발생 시 원본 이미지를 base64로 인코딩하여 반환
         - 상세 정보 (predictions, image_info 등)는 results 배열의 각 컴포넌트 결과에서 확인 가능
-        - 모든 추론 요청은 ServiceMonitoring 테이블에 자동 기록됨 (서비스와 연결된 경우)
 
-        ## Errors
-        - **400**: 워크플로우가 배포되지 않았거나 테스트할 수 없는 구성인 경우
-        - **404**: 워크플로우를 찾을 수 없는 경우
-        """
+    ## Notes
+    - 워크플로우는 배포되어 있어야 함 (ACTIVE 상태)
+    - 워크플로우에 최소 하나의 ODM MODEL 컴포넌트가 있어야 함
+    - KNOWLEDGE_BASE 컴포넌트는 포함될 수 없음 (ML 워크플로우는 ODM만 지원)
+    - 각 컴포넌트의 실행 결과는 results 배열에 순서대로 포함됨
+    - final_result는 입력 이미지에 bbox와 label이 그려진 이미지를 base64로 인코딩한 문자열
+    - bbox는 빨간색으로, label은 빨간 배경에 흰색 텍스트로 표시됨
+    - 상세 정보 (predictions, image_info 등)는 results 배열의 각 컴포넌트 결과에서 확인 가능
+    - 모든 추론 요청은 ServiceMonitoring 테이블에 자동 기록됨 (서비스와 연결된 경우)
+
+    ## Errors
+    - **400**: 잘못된 요청 (ML 워크플로우가 아님, 필수 파라미터 누락 등)
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+    - **503**: 모델 서비스가 준비되지 않음
+    - **500**: 서버 내부 오류
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -1129,6 +1775,138 @@ async def test_ml_workflow(
 
     return test_response
 
+# ===== Workflow 모델 추론 (Deprecated) =====
+
+@router.post(
+    "/{surro_workflow_id}/models/{component_id}/inference",
+    deprecated=True,
+)
+async def inference_workflow_model(
+        surro_workflow_id: str,
+        component_id: str,
+        image: Optional[UploadFile] = File(None),
+        text: Optional[str] = Form(None),
+        search_text: Optional[str] = Form(None),
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user)
+):
+    """
+    배포된 모델에 추론 요청 (Deprecated)
+
+    ⚠️ 이 API는 deprecated 되었습니다. 대신 다음 API를 사용하세요:
+    - RAG 워크플로우: `POST /api/v1/workflows/{workflow_id}/test/rag`
+    - ML 워크플로우: `POST /api/v1/workflows/{workflow_id}/test/ml`
+
+    워크플로우에서 배포된 특정 모델 컴포넌트에 추론을 수행합니다.
+    - KServe 모델: KServe V2 프로토콜을 사용하며, Object Detection 모델을 지원합니다.
+    - Ollama 모델: Ollama 채팅 API(`/api/chat`)를 사용하며, LLM 모델을 지원합니다.
+
+    게이트웨이는 호환성 유지를 위해 MLOps로 요청을 그대로 전달(프록시)합니다.
+    신규 연동에서는 위의 test API를 사용하세요.
+
+    ## Path Parameters
+    - **workflow_id** (str): 워크플로우 UUID
+    - **component_id** (str): 컴포넌트 UUID (WorkflowComponent.id)
+        - 컴포넌트 ID 조회 방법:
+          1. 워크플로우 상세 조회: `GET /api/v1/workflows/{workflow_id}`
+             - 응답의 `components` 배열에서 `id` 필드 확인
+             - `type`이 "MODEL"인 컴포넌트의 `id` 사용
+          2. 배포된 모델 목록 조회: `GET /api/v1/workflows/{workflow_id}/models`
+             - 응답의 `deployed_models` 배열에서 `component_id` 필드 확인
+             - 배포된 모델만 조회 가능 (DEPLOYED 상태)
+
+    ## Request Body (Form Data)
+    - **image** (file, optional): 분석할 이미지 파일
+        - KServe 모델인 경우 필수
+        - Ollama 모델인 경우 선택 (텍스트와 함께 사용 가능)
+        - 지원 형식: JPEG, PNG, GIF, WebP
+        - Base64로 인코딩되어 서버로 전송
+    - **text** (str, optional): 텍스트 입력
+        - Ollama 모델인 경우 필수 (image가 없는 경우)
+        - KServe 모델인 경우 사용하지 않음
+    - **search_text** (str, optional): Knowledge Base 검색 결과 텍스트
+        - Knowledge Base 컴포넌트에서 검색된 결과를 전달하는 파라미터
+        - Ollama 모델인 경우에만 사용됨
+        - prompt_id가 설정된 경우: prompt의 context 변수에 자동 치환
+        - prompt_id가 없는 경우: [참고자료] 태그와 함께 system 메시지로 추가
+
+    ## Response (통일된 형식)
+    - **workflow_id** (str): 워크플로우 UUID
+    - **component_id** (str): 컴포넌트 UUID
+    - **model_info** (dict): 모델 정보
+        - component_id (str): 컴포넌트 ID
+        - service_name (str): 서비스 이름
+        - sanitized_model_name (str): 정제된 모델 이름 (DNS 규칙 준수)
+        - model_id (int, optional): 모델 ID
+        - original_model_name (str, optional): 원본 모델 이름
+        - model_type (str, optional): 모델 타입 (예: "ODM", "LLM")
+        - model_format (str, optional): 모델 포맷 (예: "pytorch", "gguf")
+    - **result** (dict): 추론 결과
+        - **model_type** (str): 모델 타입 ("KServe" 또는 "Ollama")
+        - KServe 모델인 경우:
+            - **predictions** (List[dict]): 추론 결과 목록
+                - 각 항목은 다음 필드를 포함:
+                    - **score** (float): 객체 감지 신뢰도 점수 (0.0 ~ 1.0)
+                    - **label** (str): 감지된 객체의 레이블 (예: "person", "laptop")
+                    - **box** (List[float]): 바운딩 박스 좌표 [x1, y1, x2, y2]
+            - **image_info** (dict, optional): 이미지 메타데이터
+                - **original_size** (dict): 원본 이미지 크기
+                - **model_input_size** (dict): 모델 입력 크기
+        - Ollama 모델인 경우:
+            - **response** (str): LLM 응답 텍스트
+            - **full_response** (dict, optional): Ollama API 전체 응답
+    - **raw_response** (dict, optional): 원본 응답 (예상치 못한 형식인 경우에만 포함)
+
+    ## Monitoring
+    - 모든 추론 요청은 ServiceMonitoring 테이블에 자동 기록
+    - 응답 시간, 성공/실패 여부, 사용자 정보 포함
+    - 서비스와 연결된 경우만 모니터링 데이터 저장
+
+    ## Notes
+    ### KServe 모델
+    - Istio Gateway를 통해 KServe InferenceService에 접근
+    - V2 프로토콜 엔드포인트: `/v2/models/{model_name}/infer`
+    - Host 헤더로 Istio 라우팅 제어
+
+    ### Ollama 모델
+    - internal_url을 통해 Ollama 서비스에 직접 접근 (예: `http://localhost:11434`)
+    - 채팅 API 엔드포인트: `/api/chat`
+    - model 필드에 repo_id 사용 (예: "gemma3", "ahmgam/medllama3-v20")
+    - 이미지는 base64로 인코딩되어 메시지에 포함됨
+
+    ## Errors
+    - **400**: 잘못된 요청
+        - Ollama 모델인 경우: text 인자가 없으면 에러
+        - KServe 모델인 경우: image 인자가 없으면 에러
+        - 잘못된 이미지 파일
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우나 컴포넌트를 찾을 수 없음
+    - **503**: 모델 서비스가 준비되지 않음
+    - **504**: 추론 요청 타임아웃
+    """
+    existing_workflow = workflow_crud.get_workflow_by_surro_id(
+        db=db,
+        surro_workflow_id=surro_workflow_id
+    )
+    if not existing_workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    user_info = {
+        'member_id': current_user.member_id,
+        'role': current_user.role,
+        'name': current_user.name
+    }
+
+    return await workflow_service.inference_workflow_model(
+        workflow_id=surro_workflow_id,
+        component_id=component_id,
+        image=image,
+        text=text,
+        search_text=search_text,
+        user_info=user_info,
+    )
+
+
 # ===== Workflow 상태 및 모델 조회 =====
 
 @router.get("/{surro_workflow_id}/models")
@@ -1138,21 +1916,51 @@ async def get_workflow_models(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우에 배포된 모델 목록 조회
+    워크플로우에 배포된 모델 목록 조회
 
-        워크플로우에서 배포된 모든 ML 모델의 상세 정보를 조회합니다. KServe InferenceService로 배포된 모델들의 엔드포인트와 상태를 포함합니다.
+    워크플로우에서 배포된 모든 ML 모델의 상세 정보를 조회합니다.
+    KServe InferenceService로 배포된 모델들의 엔드포인트와 상태를 포함합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 조회할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 조회할 워크플로우 UUID
 
-        ## Notes
-        - backend_api_url은 첫 번째 배포된 모델 기준으로 생성
-        - 각 모델마다 고유한 service_name과 hostname을 가짐
-        - 배포 상태가 DEPLOYED인 모델만 추론 가능
+    ## Response
+    - **workflow_id** (str): 워크플로우 UUID
+    - **backend_api_url** (str): 추론 API URL (첫 번째 모델 기준)
+        - 형식: `{gateway_url}/v2/models/{model_name}/infer`
+    - **deployed_models** (List[dict]): 배포된 모델 목록
+        - workflow_id (str): 소속 워크플로우 ID
+        - component_id (str): 컴포넌트 ID
+        - component_name (str): 컴포넌트 이름
+        - model_id (int): 모델 ID
+        - model_name (str): 원본 모델 이름
+        - sanitized_model_name (str): DNS 규칙에 맞게 변환된 모델 이름
+        - service_name (str): KServe 서비스 이름
+        - service_hostname (str): KServe 서비스 호스트명
+        - status (str): 배포 상태
+            - "PENDING": 배포 대기중
+            - "DEPLOYED": 배포 완료
+            - "FAILED": 배포 실패
+            - "DELETED": 삭제됨
+        - internal_url (str): 내부 접근 URL
+        - gateway_url (str): 외부 게이트웨이 URL
+        - deployed_at (datetime): 배포 시각
+        - deleted_at (datetime): 삭제 시각 (삭제된 경우)
+        - error_message (str): 오류 메시지 (실패 시)
+        - created_at (datetime): 레코드 생성 시각
+        - updated_at (datetime): 레코드 업데이트 시각
+    - **total** (int): 배포된 모델 총 개수
 
-        ## Errors
-        - **404**: 워크플로우를 찾을 수 없는 경우
-        """
+    ## Notes
+    - backend_api_url은 첫 번째 배포된 모델 기준으로 생성
+    - 각 모델마다 고유한 service_name과 hostname을 가짐
+    - 배포 상태가 DEPLOYED인 모델만 추론 가능
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 서버 내부 오류
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -1184,24 +1992,45 @@ async def cleanup_workflow(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 리소스 정리 시작
+    워크플로우 리소스 정리 시작
 
-        배포된 KServe InferenceService들을 정리합니다. 워크플로우 자체는 유지하면서 배포된 리소스만 제거합니다.
+    배포된 KServe InferenceService들을 정리합니다.
+    워크플로우 자체는 유지하면서 배포된 리소스만 제거합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 정리할 워크플로우 UUID
+    ## Path Parameters
+    - **workflow_id** (str): 정리할 워크플로우 UUID
 
-        ## Process
-        1. KServe InferenceService 삭제 파이프라인 시작
-        2. cleanup_run_id 반환
-        3. finalize-cleanup API로 완료 확인
-        4. 워크플로우 상태를 DRAFT로 변경 (재실행 가능)
+    ## Response (202 Accepted)
+    - **message** (str): 상태 메시지 "Cleanup started"
+    - **workflow_id** (str): 워크플로우 UUID
+    - **cleanup_run_id** (str): 정리 파이프라인 실행 ID
+    - **status** (str): 현재 상태 "cleanup_in_progress"
+    - **next_step** (str): 다음 단계 API 안내
+        - 형식: "Call /workflows/{workflow_id}/finalize-cleanup to check completion"
 
-        ## Notes
-        - 워크플로우는 삭제되지 않고 리소스만 정리
-        - 비동기 프로세스 (202 Accepted)
-        - 정리 후 워크플로우 재실행 가능
-        """
+    ## Use Cases
+    - 비용 절감을 위해 배포된 리소스 정리
+    - 오류 발생 후 재배포 준비
+    - 워크플로우 구조 변경 전 리소스 정리
+
+    ## Process
+    1. KServe InferenceService 삭제 파이프라인 시작
+    2. cleanup_run_id 반환
+    3. `finalize-cleanup` API로 완료 확인
+    4. 워크플로우 상태를 DRAFT로 변경 (재실행 가능)
+
+    ## Notes
+    - 워크플로우는 삭제되지 않고 리소스만 정리
+    - 비동기 프로세스 (202 Accepted)
+    - 정리 후 워크플로우 재실행 가능
+    - 게이트웨이 권한 검사: admin 이거나 해당 워크플로우의 `created_by` 사용자만 정리 가능
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **403**: 권한 없음
+    - **404**: 워크플로우를 찾을 수 없음
+    - **500**: 정리 파이프라인 시작 실패
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,
@@ -1241,38 +2070,73 @@ async def finalize_workflow_cleanup(
         current_user=Depends(get_current_user)
 ):
     """
-        워크플로우 정리 완료 처리
+    워크플로우 정리 완료 처리
 
-        KServe 리소스 정리가 완료되었는지 확인하고, 완료된 경우 워크플로우 상태를 업데이트합니다. 워크플로우는 삭제되지 않고 리소스만 정리되며, 정리 후 재실행이 가능합니다.
+    Kubernetes 클러스터를 직접 조회하여 리소스가 실제로 삭제되었는지 확인하고,
+    확인된 경우 워크플로우 상태를 업데이트합니다.
+    워크플로우는 삭제되지 않고 리소스만 정리되며, 정리 후 재실행이 가능합니다.
 
-        ## Path Parameters
-        - workflow_id (str): 정리할 워크플로우 UUID
-            - 워크플로우 목록 조회 API(/workflows)에서 확인 가능
+    ## Path Parameters
+    - **workflow_id** (str): 정리할 워크플로우 UUID
+        - 워크플로우 목록 조회 API(`/workflows`)에서 확인 가능
 
-        ## Query Parameters
-        - run_id (str, required): Kubeflow Pipeline cleanup run ID
-            - cleanup API에서 반환된 cleanup_run_id 사용
-            - 형식: Kubeflow Pipeline 실행 UUID
+    ## Query Parameters
+    - **run_id** (str, required): Kubeflow Pipeline cleanup run ID
+        - cleanup API에서 반환된 cleanup_run_id 사용
+        - 형식: Kubeflow Pipeline 실행 UUID
 
-        ## Process
-        1. 워크플로우 존재 여부 확인
-        2. Pipeline 상태 확인 (5초 타임아웃)
-        3. 완료 시:
-            - 워크플로우 상태가 ERROR인 경우 DRAFT로 변경
-            - KServe 배포 데이터(kserve_deployments) 삭제
-            - 재실행 가능한 상태로 업데이트
-        4. 진행중: 진행 상태 반환 (재호출 필요)
-        5. 실패: 오류 메시지 반환
+    ## Response
+    - **workflow_id** (str): 워크플로우 UUID
+    - **status** (str): 정리 상태
+        - "completed": 정리 완료
+            - Kubernetes 리소스가 실제로 삭제되어 확인됨
+            - 워크플로우 상태가 업데이트됨 (ERROR → DRAFT)
+        - "in_progress": 아직 진행중
+            - Kubernetes에 리소스가 아직 존재함
+            - 완료될 때까지 대기 후 재호출 필요
+        - "failed": 정리 실패
+            - Kubernetes 리소스 확인 중 오류 발생
+            - error_message에 상세 오류 정보 포함
+    - **workflow_updated** (bool): 워크플로우 상태 업데이트 여부
+        - true: 워크플로우 상태가 성공적으로 업데이트됨
+            - ERROR 상태였던 경우 DRAFT로 변경됨
+            - 재실행 가능한 상태로 변경됨
+        - false: 워크플로우 상태가 업데이트되지 않음
+            - 리소스가 아직 삭제되지 않았거나 실패한 경우
+            - 또는 워크플로우가 이미 DRAFT 상태인 경우
+    - **message** (str): 상태 메시지
+        - 정리 완료: "Cleanup completed and workflow state updated"
+        - 진행중: "Resources still exist in Kubernetes, waiting for cleanup"
+        - 실패: "Failed to check Kubernetes resources: {error}"
 
-        ## Notes
-        - 워크플로우는 삭제되지 않고 리소스만 정리됨
-        - 정리 완료 후 워크플로우를 재실행할 수 있음
-        - Pipeline 상태 확인은 짧은 타임아웃(5초)으로 즉시 확인
-        - Pipeline이 아직 진행중이면 재호출하여 완료 확인 필요
-        - ERROR 상태의 워크플로우는 정리 완료 시 DRAFT로 변경됨
-        - 이미 DRAFT 상태인 워크플로우는 상태 변경 없음
-        - cleanup API 호출 후 이 API를 호출하여 완료 확인 필요
-        """
+    ## Process
+    1. 워크플로우 존재 여부 확인
+    2. Kubernetes 클러스터에서 리소스 직접 조회
+       - InferenceService 조회
+       - Ollama Deployment/Service 조회
+    3. 리소스가 모두 삭제된 경우:
+       - 워크플로우 상태가 ERROR인 경우 DRAFT로 변경
+       - KServe 배포 데이터(kserve_deployments) 삭제
+       - 재실행 가능한 상태로 업데이트
+    4. 리소스가 아직 존재하는 경우: 진행중 상태 반환 (재호출 필요)
+    5. 확인 중 오류 발생: 실패 상태 반환
+
+    ## Notes
+    - 워크플로우는 삭제되지 않고 리소스만 정리됨
+    - 정리 완료 후 워크플로우를 재실행할 수 있음
+    - Kubernetes 리소스 확인은 즉시 수행됨
+    - 리소스가 아직 존재하면 재호출하여 완료 확인 필요
+    - ERROR 상태의 워크플로우는 정리 완료 시 DRAFT로 변경됨
+    - 이미 DRAFT 상태인 워크플로우는 상태 변경 없음
+    - cleanup API 호출 후 이 API를 호출하여 완료 확인 필요
+
+    ## Errors
+    - **401**: 인증되지 않은 사용자
+    - **404**: 워크플로우를 찾을 수 없음
+        - workflow_id가 존재하지 않거나 삭제된 경우
+    - **500**: 정리 처리 중 오류 발생
+        - Kubernetes 리소스 확인 실패 또는 워크플로우 상태 업데이트 실패
+    """
     # 권한 확인
     existing_workflow = workflow_crud.get_workflow_by_surro_id(
         db=db,

--- a/app/schemas/experiment.py
+++ b/app/schemas/experiment.py
@@ -55,6 +55,14 @@ class ExperimentListItem(BaseModel):
     updated_at: Optional[datetime] = Field(None, description="실험 수정 시각")
 
 
+class ExperimentListResponse(BaseModel):
+    """실험 목록 응답"""
+    data: List[ExperimentListItem] = Field(..., description="실험 목록")
+    total: int = Field(..., description="전체 항목 수")
+    page: int = Field(..., description="현재 페이지 번호")
+    size: int = Field(..., description="페이지당 항목 수")
+
+
 class ExperimentDetailResponse(BaseModel):
     """실험 상세 응답"""
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -660,6 +660,102 @@ class ModelService:
                 detail=f"Internal error: {str(e)}"
             )
 
+    async def auto_generate_model(
+            self,
+            model_key: str,
+            user_info: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """사전 정의 모델 자동 등록
+
+        MLOps의 POST /models/auto-generate 을 호출합니다.
+        provider/type/format 등의 메타 정보가 MLOps 내부에서 자동으로 설정됩니다.
+        """
+        try:
+            url = f"{self.base_url}/models/auto-generate"
+            params = {"model_key": model_key}
+
+            logger.info(f"Auto-generating model at: {url} (model_key={model_key})")
+
+            response = await self._make_authenticated_request(
+                "POST", url, user_info=user_info, params=params
+            )
+
+            if response.status_code in [200, 201]:
+                return response.json()
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"Failed to auto-generate model: {response.text}"
+            )
+
+        except httpx.TimeoutException as e:
+            logger.error(f"Timeout auto-generating model: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="External service timeout"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error auto-generating model: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Internal error: {str(e)}"
+            )
+
+    async def update_base_deployment_status(
+            self,
+            model_id: int,
+            service_name: str,
+            service_hostname: str,
+            deployment_status: str,
+            internal_url: Optional[str] = None,
+            error_message: Optional[str] = None,
+            user_info: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """모델 기본 배포 상태 업데이트 (내부 API 프록시)
+
+        Kubeflow 파이프라인 컴포넌트에서만 호출되는 내부 API로,
+        게이트웨이는 호환성을 위해 그대로 프록시합니다.
+        """
+        try:
+            url = f"{self.base_url}/models/base-deployments/{model_id}/status"
+            payload = {
+                "service_name": service_name,
+                "service_hostname": service_hostname,
+                "status": deployment_status,
+            }
+            if internal_url is not None:
+                payload["internal_url"] = internal_url
+            if error_message is not None:
+                payload["error_message"] = error_message
+
+            response = await self._make_authenticated_request(
+                "PUT", url, user_info=user_info, json=payload,
+                headers={'Content-Type': 'application/json'}
+            )
+
+            if response.status_code == 200:
+                return response.json()
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"Failed to update base deployment status: {response.text}"
+            )
+
+        except httpx.TimeoutException as e:
+            logger.error(f"Timeout updating base deployment status: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="External service timeout"
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error updating base deployment status: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Internal error: {str(e)}"
+            )
+
     async def get_model_formats(
             self,
             user_info: Optional[Dict[str, str]] = None,

--- a/app/services/workflow_service.py
+++ b/app/services/workflow_service.py
@@ -403,6 +403,53 @@ class WorkflowService:
             logger.error(f"Error testing ML workflow: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))
 
+    async def inference_workflow_model(
+            self,
+            workflow_id: str,
+            component_id: str,
+            image: Optional[UploadFile] = None,
+            text: Optional[str] = None,
+            search_text: Optional[str] = None,
+            user_info: Optional[Dict] = None,
+    ) -> Dict[str, Any]:
+        """배포된 모델에 추론 요청 (Deprecated)
+
+        MLOps는 이 엔드포인트를 deprecated 처리했으며 내부적으로 test/rag 또는 test/ml로
+        대체 사용을 권장합니다. 호환성 유지를 위해 프록시만 제공합니다.
+        """
+        try:
+            url = f"{self.base_url}/workflows/{workflow_id}/models/{component_id}/inference"
+
+            data = {}
+            files = {}
+            if text is not None:
+                data['text'] = text
+            if search_text is not None:
+                data['search_text'] = search_text
+            if image is not None:
+                files['image'] = (image.filename, await image.read(), image.content_type)
+
+            kwargs = {}
+            if files:
+                kwargs['files'] = files
+                if data:
+                    kwargs['data'] = data
+            elif data:
+                kwargs['data'] = data
+
+            response = await self._make_authenticated_request(
+                "POST", url, user_info=user_info, **kwargs
+            )
+
+            if response.status_code == 200:
+                return response.json()
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error(f"Error inferring workflow model: {str(e)}")
+            raise HTTPException(status_code=500, detail=str(e))
+
     # ===== Template 관련 =====
 
     async def get_templates(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ python-jose[cryptography]==3.5.0
 python-multipart==0.0.26
 starlette>=1.0.0
 httpx==0.28.1
-pytest==8.3.5
+pytest==9.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ alembic==1.18.4
 email-validator==2.3.0
 bcrypt==4.3.0
 python-jose[cryptography]==3.5.0
-python-multipart==0.0.24
+python-multipart==0.0.26
 starlette>=1.0.0
 httpx==0.28.1
 pytest==8.3.5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,24 +34,39 @@ curl -sS -o scripts/local/mlops_openapi.json http://***REDACTED***:30080/openapi
 
 ## GET API 비교 테스트
 
+계정 정보는 커밋 금지. 로컬 게이트웨이 계정은 팀 내부에서 전달받고, MLOps는 `.env`의
+`EXTERNAL_API_USERNAME` / `EXTERNAL_API_PASSWORD`를 사용합니다.
+
+아래 예시는 쉘 변수로 먼저 주입한 뒤 호출하는 형태입니다. 히스토리 남기기 싫으면
+`read -s`로 입력받아도 됩니다.
+
 ```bash
-# 1) 로컬 게이트웨이 로그인 (admin / ***REDACTED***)
+# (권장) 셸 히스토리에 평문 비밀번호가 남지 않도록 read -s로 입력
+read -sp "Local admin password: " LOCAL_PW && echo
+read -sp "MLOps password: " MLOPS_PW && echo
+# 또는 .env에서 로드: source <(grep -E '^EXTERNAL_API_(USERNAME|PASSWORD)=' .env)
+
+# 1) 로컬 게이트웨이 로그인 (member_id는 팀 관리자 계정)
 curl -s -X POST http://127.0.0.1:8000/api/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"member_id":"admin","password":"***REDACTED***"}' \
+  -d "{\"member_id\":\"<LOCAL_MEMBER_ID>\",\"password\":\"$LOCAL_PW\"}" \
   | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" \
   > scripts/local/.tok_local
 
-# 2) MLOps 로그인 (.env의 EXTERNAL_API_USERNAME/PASSWORD)
+# 2) MLOps 로그인 (.env의 EXTERNAL_API_USERNAME / EXTERNAL_API_PASSWORD)
 curl -s -X POST http://***REDACTED***:30080/api/v1/authentications/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d 'username=***REDACTED***&password=***REDACTED***' \
+  --data-urlencode "username=$EXTERNAL_API_USERNAME" \
+  --data-urlencode "password=$MLOPS_PW" \
   | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" \
   > scripts/local/.tok_mlops
 
 # 3) 비교 테스트 실행
 python scripts/local/test_workflow_gets.py
 
-# 4) 테스트 후 토큰 정리
+# 4) 테스트 후 토큰 파기
 rm scripts/local/.tok_local scripts/local/.tok_mlops
+unset LOCAL_PW MLOPS_PW
 ```
+
+> ⚠️ **보안 주의**: 실제 비밀번호를 README, 스크립트, 커밋 메시지에 하드코딩 금지. 변수/파일(.env)로만 취급하고, `scripts/local/.tok_*`는 세션 종료 시 반드시 삭제.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+# scripts/
+
+개발·운영용 Python 스크립트 저장 폴더.
+
+## 관리 규약
+
+| 위치 | 용도 | Git |
+|---|---|---|
+| `scripts/*.py` | **커밋 대상**: 팀 공유 개발 도구 (예: 데이터 싱크, 마이그레이션 보조 등) | 트래킹 |
+| `scripts/local/**` | **로컬 전용**: 로컬 테스트 스크립트, MLOps OpenAPI 덤프, 임시 토큰 등 | `.gitignore`로 제외 |
+
+`scripts/local/`은 `.gitignore`에서 디렉토리 단위로 무시되므로, 로컬 전용 파일을 이 하위에 두면
+개별 패턴을 `.gitignore`에 추가하지 않아도 됩니다.
+
+## 현재 파일
+
+### scripts/ (트래킹)
+- `sync_datasets.py` — 데이터셋 동기화 스크립트
+
+### scripts/local/ (로컬 전용)
+- `mlops_openapi.json` — MLOps `/openapi.json` 덤프 (스웨거 설명 동기화용 참조)
+- `mlops_workflows_summary.txt` — 위 덤프에서 Workflows 섹션만 추출한 요약
+- `mlops_models_summary.txt` — 위 덤프에서 Models 섹션만 추출한 요약
+- `test_workflow_gets.py` — 게이트웨이(127.0.0.1:8000) vs MLOps(***REDACTED***:30080) GET 비교 스크립트
+- `.tok_local`, `.tok_mlops` — 로그인 토큰 임시 저장 (테스트 후 삭제 권장)
+
+## MLOps OpenAPI 재다운로드
+
+스웨거 설명 최신화 등이 필요할 때:
+
+```bash
+curl -sS -o scripts/local/mlops_openapi.json http://***REDACTED***:30080/openapi.json
+```
+
+## GET API 비교 테스트
+
+```bash
+# 1) 로컬 게이트웨이 로그인 (admin / ***REDACTED***)
+curl -s -X POST http://127.0.0.1:8000/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"member_id":"admin","password":"***REDACTED***"}' \
+  | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" \
+  > scripts/local/.tok_local
+
+# 2) MLOps 로그인 (.env의 EXTERNAL_API_USERNAME/PASSWORD)
+curl -s -X POST http://***REDACTED***:30080/api/v1/authentications/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d 'username=***REDACTED***&password=***REDACTED***' \
+  | python -c "import sys,json; print(json.load(sys.stdin)['access_token'])" \
+  > scripts/local/.tok_mlops
+
+# 3) 비교 테스트 실행
+python scripts/local/test_workflow_gets.py
+
+# 4) 테스트 후 토큰 정리
+rm scripts/local/.tok_local scripts/local/.tok_mlops
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@
 - `mlops_openapi.json` — MLOps `/openapi.json` 덤프 (스웨거 설명 동기화용 참조)
 - `mlops_workflows_summary.txt` — 위 덤프에서 Workflows 섹션만 추출한 요약
 - `mlops_models_summary.txt` — 위 덤프에서 Models 섹션만 추출한 요약
-- `test_workflow_gets.py` — 게이트웨이(127.0.0.1:8000) vs MLOps(***REDACTED***:30080) GET 비교 스크립트
+- `test_workflow_gets.py` — 게이트웨이(127.0.0.1:8000) vs MLOps(`<MLOPS_BASE_URL>`) GET 비교 스크립트
 - `.tok_local`, `.tok_mlops` — 로그인 토큰 임시 저장 (테스트 후 삭제 권장)
 
 ## MLOps OpenAPI 재다운로드
@@ -29,7 +29,8 @@
 스웨거 설명 최신화 등이 필요할 때:
 
 ```bash
-curl -sS -o scripts/local/mlops_openapi.json http://***REDACTED***:30080/openapi.json
+export MLOPS_BASE_URL="http://<mlops-host>:<mlops-port>"
+curl -sS -o scripts/local/mlops_openapi.json "$MLOPS_BASE_URL/openapi.json"
 ```
 
 ## GET API 비교 테스트
@@ -44,6 +45,7 @@ curl -sS -o scripts/local/mlops_openapi.json http://***REDACTED***:30080/openapi
 # (권장) 셸 히스토리에 평문 비밀번호가 남지 않도록 read -s로 입력
 read -sp "Local admin password: " LOCAL_PW && echo
 read -sp "MLOps password: " MLOPS_PW && echo
+export MLOPS_BASE_URL="http://<mlops-host>:<mlops-port>"
 # 또는 .env에서 로드: source <(grep -E '^EXTERNAL_API_(USERNAME|PASSWORD)=' .env)
 
 # 1) 로컬 게이트웨이 로그인 (member_id는 팀 관리자 계정)
@@ -54,7 +56,7 @@ curl -s -X POST http://127.0.0.1:8000/api/v1/auth/login \
   > scripts/local/.tok_local
 
 # 2) MLOps 로그인 (.env의 EXTERNAL_API_USERNAME / EXTERNAL_API_PASSWORD)
-curl -s -X POST http://***REDACTED***:30080/api/v1/authentications/token \
+curl -s -X POST "$MLOPS_BASE_URL/api/v1/authentications/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   --data-urlencode "username=$EXTERNAL_API_USERNAME" \
   --data-urlencode "password=$MLOPS_PW" \

--- a/scripts/sync_datasets.py
+++ b/scripts/sync_datasets.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.cruds.dataset import dataset_crud
+from app.database import SessionLocal
+from app.models.member import Member
+from app.services.dataset_service import dataset_service
+
+
+ADMIN_MEMBER_ID = "admin"
+
+
+def _serialize_summary(summary: dict[str, Any]) -> str:
+    return json.dumps(summary, ensure_ascii=False, indent=2, default=str)
+
+
+async def sync_admin_datasets() -> dict[str, Any]:
+    db: Session = SessionLocal()
+    try:
+        admin = db.query(Member).filter(Member.member_id == ADMIN_MEMBER_ID).first()
+        if not admin:
+            raise RuntimeError(f"Admin member not found: {ADMIN_MEMBER_ID}")
+
+        external_response = await dataset_service.get_datasets(
+            page=None,
+            page_size=None,
+            user_info={
+                "member_id": admin.member_id,
+                "role": admin.role,
+                "name": admin.name,
+            },
+        )
+
+        external_datasets = external_response.data
+        external_ids = [dataset.id for dataset in external_datasets]
+
+        synced = []
+        for dataset in external_datasets:
+            mapping = dataset_crud.upsert_dataset_mapping(
+                db=db,
+                surro_dataset_id=dataset.id,
+                member_id=admin.member_id,
+                dataset_name=dataset.name,
+            )
+            synced.append(
+                {
+                    "db_id": mapping.id,
+                    "surro_dataset_id": mapping.surro_dataset_id,
+                    "name": mapping.name,
+                    "created_by": mapping.created_by,
+                    "is_active": mapping.is_active,
+                }
+            )
+
+        soft_deleted_count = dataset_crud.soft_delete_missing_mappings(
+            db=db,
+            member_id=admin.member_id,
+            active_surro_dataset_ids=external_ids,
+            deleted_by=admin.member_id,
+        )
+
+        remaining_active = dataset_crud.get_dataset_mappings_by_member_id(
+            db=db,
+            member_id=admin.member_id,
+            skip=0,
+            limit=10000,
+        )
+
+        return {
+            "admin_member_id": admin.member_id,
+            "external_dataset_count": len(external_datasets),
+            "external_dataset_ids": external_ids,
+            "synced": synced,
+            "soft_deleted_count": soft_deleted_count,
+            "remaining_active_dataset_ids": sorted(remaining_active.keys()),
+        }
+    finally:
+        db.close()
+        await dataset_service.close()
+
+
+if __name__ == "__main__":
+    result = asyncio.run(sync_admin_datasets())
+    print(_serialize_summary(result))


### PR DESCRIPTION
## Summary

이번 릴리스는 크게 세 덩어리입니다.

### 🔒 보안 대응
- **Dependabot #8** — `python-multipart` 0.0.24 → 0.0.26 (CVE-2026-40347, CVSS 5.3)
  대용량 multipart preamble/epilogue DoS. Dataset 최대 1GB 업로드 경로가 있어 우선 패치.
- **Dependabot #7** — `pytest` 8.3.5 → 9.0.3 (CVE-2025-71176, CVSS 6.8)
  dev 의존성. tests/ 70개 전부 통과 확인.
- **Code scanning #2** — `.github/workflows/deploy.yml`에 최소 권한 블록(`contents: read`) 추가.

### ✨ 기능 확장
- **학습 API 신설** — `app/routes/learning.py` 추가(+709), 학습 목록 조회 및 페이지네이션 구현.
- **워크플로우 API 확장** — 생성·수정 API 확장, 추론 API 신규 추가(+1127), 기존 추론 API deprecated 처리.
- **모델 API 개선** — 등록·조회 API 개선, 사전 정의 모델 자동 등록 기능 추가.
- **파이프라인 API** — 학습 파이프라인 생성·실행 API 업데이트.

### 🚀 배포 인프라
- `deploy.yml`에 matrix runner(`aipaas-backend`, `ai-paas-gateway`) 추가.
- `.gitignore`에 로컬 전용 스크립트·덤프 경로 추가.
